### PR TITLE
Distortion correction corrected at f=48mm (Zoom-Nikkor 28-200)

### DIFF
--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -3072,6 +3072,7 @@
             <!-- Taken with Nikon D600 -->
             <distortion model="ptlens" focal="28" a="0.03547" b="-0.10778" c="0.08687" />
             <distortion model="ptlens" focal="38" a="0.02089" b="-0.04522" c="0.02617" />
+            <distortion model="ptlens" focal="48" a="0.01934" b="-0.04754" c="0.04983" />
             <distortion model="ptlens" focal="62" a="0.0182" b="-0.03995" c="0.04876" />
             <distortion model="ptlens" focal="85" a="0.01073" b="-0.00974" c="0.0161" />
             <distortion model="ptlens" focal="125" a="0.00065" b="0.03125" c="-0.03952" />


### PR DESCRIPTION
Adding correct 48mm distorion line for Nikon AF Zoom-Nikkor 28-200mm f/3.5-5.6G IF-ED. Original calibration upload — 215f9b_jamie.