### PR TITLE
Added Tamron SP 90mm f/2.8 Di VC USD Macro 1:1

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -750,4 +750,17 @@
         </calibration>
     </lens>
 
+    <lens>
+        <maker>Tamron</maker>
+        <model>Tamron SP 90mm f/2.8 Di VC USD Macro 1:1 F004</model>
+        <model lang="en">Tamron SP 90mm f/2.8 Di VC USD Macro 1:1</model>
+        <mount>Canon EF</mount>
+        <cropfactor>1.005</cropfactor>
+        <calibration>
+            <!-- taken with Canon EOS 700D -->
+            <distortion model="ptlens" focal="90" a="-0.00692" b="0.018" c="-0.00702"/>
+            <tca model="poly3" focal="90" vr="1.0000890" vb="1.0000142"/>
+        </calibration>
+    </lens>
+
 </lensdatabase>


### PR DESCRIPTION
This lens is reported as "Canon EF 100mm f/2.8L Macro IS USM" to
darktable by exiv2 so auto selecting of lens does not work.

Output of exiv2 show both lens names:
`
$ exiv2 -pt Tamron_SP_90mm_f__2.8_Di_VC_USD_MACRO_1_1--90mm--4.CR2 | grep -ai lens

Warning: Directory Canon, entry 0x0000 has unknown Exif (TIFF) type 0; setting type size 1.
Exif.CanonCs.LensType                        Short       1  Canon EF 100mm f/2.8L Macro IS USM
Exif.CanonCs.Lens                            Short       3  90.0 mm
Exif.Canon.LensModel                         Ascii      74  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004
Exif.Photo.LensModel                         Ascii      45  TAMRON SP 90mm F/2.8 Di VC USD MACRO1:1 F004
`

Upload folder 39f757_

1) What should I do with wrong exiv2 output?

2) Is cropfactor OK as this is general for Canon EF mount, but does not fit to EOS 700D? What is the crop factor used for in calibration?

3) Always include aspect ration in *.xml? 

4) Also include Sony Alpha and Nikon F AF also I don't have test images?