### PR TITLE
Fix simple-tca handling in calibrate.py

### DIFF
--- a/tools/calibrate/calibrate.py
+++ b/tools/calibrate/calibrate.py
@@ -265,7 +265,7 @@ except IOError:
 # TCA correction
 #
 
-only_linear_tca = len(sys.argv) <= 1 or sys.argv[1] == "--simple-tca"
+only_linear_tca = len(sys.argv) > 1 and sys.argv[1] == "--simple-tca"
 
 def generate_tca_tiffs(filename):
     tca_filename = filename + ".tca"


### PR DESCRIPTION
Only switch on simple-tca if it is requested. Passing no arguments will
now select the full model.