### PR TITLE
compact-canon.xml: Add full A610 profile for CHDK DNGs

### DIFF
--- a/data/db/compact-canon.xml
+++ b/data/db/compact-canon.xml
@@ -1219,6 +1219,196 @@
 
     <lens>
         <maker>Canon</maker>
+        <model>Canon PowerShot A610 &amp; compatibles, with CHDK's DNG</model>
+        <model lang="en">fixed lens, with CHDK's DNG</model>
+        <model lang="de">festes Objektiv, mit CHDK-DNG</model>
+        <mount>canonA610</mount>
+        <cropfactor>4.8</cropfactor>
+        <aspect-ratio>4:3</aspect-ratio>
+        <calibration>
+            <distortion model="ptlens" focal="7.3" a="0.006931" b="-0.02547" c="0.006226"/>
+            <distortion model="ptlens" focal="8.5" a="0.007764" b="-0.02951" c="0.016444"/>
+            <distortion model="ptlens" focal="9.6" a="0.007302" b="-0.023408" c="0.013186"/>
+            <distortion model="ptlens" focal="10.8" a="-0.003107" b="0.009694" c="-0.011024"/>
+            <distortion model="ptlens" focal="12.6" a="-0.003635" b="0.007541" c="-0.002584"/>
+            <distortion model="ptlens" focal="14.9" a="-0.0013" b="0.002528" c="0"/>
+            <distortion model="ptlens" focal="17.3" a="-0.001404" b="0.014591" c="-0.024707"/>
+            <distortion model="ptlens" focal="21.7" a="0.000238" b="0.005374" c="-0.016188"/>
+            <distortion model="ptlens" focal="29.2" a="-0.035658" b="0.101639" c="-0.087315"/>
+            <tca model="poly3" focal="7.3" vr="1.0004523" vb="1.0001479"/>
+            <tca model="poly3" focal="8.5" vr="1.0006219" vb="0.9999944"/>
+            <tca model="poly3" focal="9.6" vr="1.0004274" vb="1.0000258"/>
+            <tca model="poly3" focal="10.8" vr="1.0002813" vb="1.0001387"/>
+            <tca model="poly3" focal="12.6" vr="1.0001260" vb="1.0001707"/>
+            <tca model="poly3" focal="14.9" vr="1.0000493" vb="1.0002103"/>
+            <tca model="poly3" focal="17.3" vr="0.9999945" vb="1.0002257"/>
+            <tca model="poly3" focal="21.7" vr="1.0000291" vb="1.0001431"/>
+            <tca model="poly3" focal="29.2" vr="1.0000026" vb="1.0000523"/>
+            <vignetting model="pa" focal="7.3" aperture="2.8" distance="10" k1="-0.4086" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="7.3" aperture="2.8" distance="1000" k1="-0.4086" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="7.3" aperture="3.1" distance="10" k1="-0.4089" k2="1.5607" k3="-1.3926"/>
+            <vignetting model="pa" focal="7.3" aperture="3.1" distance="1000" k1="-0.4089" k2="1.5607" k3="-1.3926"/>
+            <vignetting model="pa" focal="7.3" aperture="3.5" distance="10" k1="-0.4089" k2="1.5606" k3="-1.3925"/>
+            <vignetting model="pa" focal="7.3" aperture="3.5" distance="1000" k1="-0.4089" k2="1.5606" k3="-1.3925"/>
+            <vignetting model="pa" focal="7.3" aperture="4" distance="10" k1="-0.4085" k2="1.5591" k3="-1.3911"/>
+            <vignetting model="pa" focal="7.3" aperture="4" distance="1000" k1="-0.4085" k2="1.5591" k3="-1.3911"/>
+            <vignetting model="pa" focal="7.3" aperture="4.4" distance="10" k1="-0.4087" k2="1.5601" k3="-1.3921"/>
+            <vignetting model="pa" focal="7.3" aperture="4.4" distance="1000" k1="-0.4087" k2="1.5601" k3="-1.3921"/>
+            <vignetting model="pa" focal="7.3" aperture="5" distance="10" k1="-0.4087" k2="1.5601" k3="-1.3920"/>
+            <vignetting model="pa" focal="7.3" aperture="5" distance="1000" k1="-0.4087" k2="1.5601" k3="-1.3920"/>
+            <vignetting model="pa" focal="7.3" aperture="5.6" distance="10" k1="-0.4088" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="7.3" aperture="5.6" distance="1000" k1="-0.4088" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="7.3" aperture="6.3" distance="10" k1="-0.4085" k2="1.5592" k3="-1.3911"/>
+            <vignetting model="pa" focal="7.3" aperture="6.3" distance="1000" k1="-0.4085" k2="1.5592" k3="-1.3911"/>
+            <vignetting model="pa" focal="7.3" aperture="7.1" distance="10" k1="-0.4086" k2="1.5595" k3="-1.3915"/>
+            <vignetting model="pa" focal="7.3" aperture="7.1" distance="1000" k1="-0.4086" k2="1.5595" k3="-1.3915"/>
+            <vignetting model="pa" focal="7.3" aperture="8" distance="10" k1="-0.4087" k2="1.5600" k3="-1.3918"/>
+            <vignetting model="pa" focal="7.3" aperture="8" distance="1000" k1="-0.4087" k2="1.5600" k3="-1.3918"/>
+            <vignetting model="pa" focal="8.5" aperture="2.9" distance="10" k1="-0.4086" k2="1.5596" k3="-1.3916"/>
+            <vignetting model="pa" focal="8.5" aperture="2.9" distance="1000" k1="-0.4086" k2="1.5596" k3="-1.3916"/>
+            <vignetting model="pa" focal="8.5" aperture="3.1" distance="10" k1="-0.4088" k2="1.5603" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="3.1" distance="1000" k1="-0.4088" k2="1.5603" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="3.5" distance="10" k1="-0.4087" k2="1.5598" k3="-1.3918"/>
+            <vignetting model="pa" focal="8.5" aperture="3.5" distance="1000" k1="-0.4087" k2="1.5598" k3="-1.3918"/>
+            <vignetting model="pa" focal="8.5" aperture="4" distance="10" k1="-0.4085" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="8.5" aperture="4" distance="1000" k1="-0.4085" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="8.5" aperture="4.4" distance="10" k1="-0.4087" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="4.4" distance="1000" k1="-0.4087" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="5" distance="10" k1="-0.4085" k2="1.5593" k3="-1.3912"/>
+            <vignetting model="pa" focal="8.5" aperture="5" distance="1000" k1="-0.4085" k2="1.5593" k3="-1.3912"/>
+            <vignetting model="pa" focal="8.5" aperture="5.6" distance="10" k1="-0.4086" k2="1.5598" k3="-1.3918"/>
+            <vignetting model="pa" focal="8.5" aperture="5.6" distance="1000" k1="-0.4086" k2="1.5598" k3="-1.3918"/>
+            <vignetting model="pa" focal="8.5" aperture="6.3" distance="10" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="8.5" aperture="6.3" distance="1000" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="8.5" aperture="7.1" distance="10" k1="-0.4088" k2="1.5603" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="7.1" distance="1000" k1="-0.4088" k2="1.5603" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="8" distance="10" k1="-0.4087" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="8.5" aperture="8" distance="1000" k1="-0.4087" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="9.6" aperture="3" distance="10" k1="-0.4087" k2="1.5601" k3="-1.3921"/>
+            <vignetting model="pa" focal="9.6" aperture="3" distance="1000" k1="-0.4087" k2="1.5601" k3="-1.3921"/>
+            <vignetting model="pa" focal="9.6" aperture="3.1" distance="10" k1="-0.4085" k2="1.5593" k3="-1.3913"/>
+            <vignetting model="pa" focal="9.6" aperture="3.1" distance="1000" k1="-0.4085" k2="1.5593" k3="-1.3913"/>
+            <vignetting model="pa" focal="9.6" aperture="3.5" distance="10" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="9.6" aperture="3.5" distance="1000" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="9.6" aperture="4" distance="10" k1="-0.4089" k2="1.5607" k3="-1.3925"/>
+            <vignetting model="pa" focal="9.6" aperture="4" distance="1000" k1="-0.4089" k2="1.5607" k3="-1.3925"/>
+            <vignetting model="pa" focal="9.6" aperture="4.4" distance="10" k1="-0.4087" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="9.6" aperture="4.4" distance="1000" k1="-0.4087" k2="1.5602" k3="-1.3921"/>
+            <vignetting model="pa" focal="9.6" aperture="5" distance="10" k1="-0.4086" k2="1.5596" k3="-1.3915"/>
+            <vignetting model="pa" focal="9.6" aperture="5" distance="1000" k1="-0.4086" k2="1.5596" k3="-1.3915"/>
+            <vignetting model="pa" focal="9.6" aperture="5.6" distance="10" k1="-0.4086" k2="1.5596" k3="-1.3916"/>
+            <vignetting model="pa" focal="9.6" aperture="5.6" distance="1000" k1="-0.4086" k2="1.5596" k3="-1.3916"/>
+            <vignetting model="pa" focal="9.6" aperture="6.3" distance="10" k1="-0.4084" k2="1.5590" k3="-1.3910"/>
+            <vignetting model="pa" focal="9.6" aperture="6.3" distance="1000" k1="-0.4084" k2="1.5590" k3="-1.3910"/>
+            <vignetting model="pa" focal="9.6" aperture="7.1" distance="10" k1="-0.4084" k2="1.5591" k3="-1.3911"/>
+            <vignetting model="pa" focal="9.6" aperture="7.1" distance="1000" k1="-0.4084" k2="1.5591" k3="-1.3911"/>
+            <vignetting model="pa" focal="9.6" aperture="8" distance="10" k1="-0.4084" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="9.6" aperture="8" distance="1000" k1="-0.4084" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="10.8" aperture="3.1" distance="10" k1="-0.4085" k2="1.5592" k3="-1.3911"/>
+            <vignetting model="pa" focal="10.8" aperture="3.1" distance="1000" k1="-0.4085" k2="1.5592" k3="-1.3911"/>
+            <vignetting model="pa" focal="10.8" aperture="3.5" distance="10" k1="-0.4083" k2="1.5587" k3="-1.3907"/>
+            <vignetting model="pa" focal="10.8" aperture="3.5" distance="1000" k1="-0.4083" k2="1.5587" k3="-1.3907"/>
+            <vignetting model="pa" focal="10.8" aperture="4" distance="10" k1="-0.4087" k2="1.5600" k3="-1.3919"/>
+            <vignetting model="pa" focal="10.8" aperture="4" distance="1000" k1="-0.4087" k2="1.5600" k3="-1.3919"/>
+            <vignetting model="pa" focal="10.8" aperture="4.4" distance="10" k1="-0.4085" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="10.8" aperture="4.4" distance="1000" k1="-0.4085" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="10.8" aperture="5" distance="10" k1="-0.4085" k2="1.5595" k3="-1.3915"/>
+            <vignetting model="pa" focal="10.8" aperture="5" distance="1000" k1="-0.4085" k2="1.5595" k3="-1.3915"/>
+            <vignetting model="pa" focal="10.8" aperture="5.6" distance="10" k1="-0.4086" k2="1.5597" k3="-1.3917"/>
+            <vignetting model="pa" focal="10.8" aperture="5.6" distance="1000" k1="-0.4086" k2="1.5597" k3="-1.3917"/>
+            <vignetting model="pa" focal="10.8" aperture="6.3" distance="10" k1="-0.4087" k2="1.5599" k3="-1.3918"/>
+            <vignetting model="pa" focal="10.8" aperture="6.3" distance="1000" k1="-0.4087" k2="1.5599" k3="-1.3918"/>
+            <vignetting model="pa" focal="10.8" aperture="7.1" distance="10" k1="-0.4084" k2="1.5589" k3="-1.3909"/>
+            <vignetting model="pa" focal="10.8" aperture="7.1" distance="1000" k1="-0.4084" k2="1.5589" k3="-1.3909"/>
+            <vignetting model="pa" focal="10.8" aperture="8" distance="10" k1="-0.4082" k2="1.5582" k3="-1.3903"/>
+            <vignetting model="pa" focal="10.8" aperture="8" distance="1000" k1="-0.4082" k2="1.5582" k3="-1.3903"/>
+            <vignetting model="pa" focal="12.6" aperture="3.2" distance="10" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="12.6" aperture="3.2" distance="1000" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="12.6" aperture="3.5" distance="10" k1="-0.4085" k2="1.5592" k3="-1.3911"/>
+            <vignetting model="pa" focal="12.6" aperture="3.5" distance="1000" k1="-0.4085" k2="1.5592" k3="-1.3911"/>
+            <vignetting model="pa" focal="12.6" aperture="4" distance="10" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="12.6" aperture="4" distance="1000" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="12.6" aperture="4.4" distance="10" k1="-0.4087" k2="1.5599" k3="-1.3919"/>
+            <vignetting model="pa" focal="12.6" aperture="4.4" distance="1000" k1="-0.4087" k2="1.5599" k3="-1.3919"/>
+            <vignetting model="pa" focal="12.6" aperture="5" distance="10" k1="-0.4086" k2="1.5595" k3="-1.3914"/>
+            <vignetting model="pa" focal="12.6" aperture="5" distance="1000" k1="-0.4086" k2="1.5595" k3="-1.3914"/>
+            <vignetting model="pa" focal="12.6" aperture="5.6" distance="10" k1="-0.4084" k2="1.5590" k3="-1.3910"/>
+            <vignetting model="pa" focal="12.6" aperture="5.6" distance="1000" k1="-0.4084" k2="1.5590" k3="-1.3910"/>
+            <vignetting model="pa" focal="12.6" aperture="6.3" distance="10" k1="-0.4086" k2="1.5597" k3="-1.3917"/>
+            <vignetting model="pa" focal="12.6" aperture="6.3" distance="1000" k1="-0.4086" k2="1.5597" k3="-1.3917"/>
+            <vignetting model="pa" focal="12.6" aperture="7.1" distance="10" k1="-0.4086" k2="1.5596" k3="-1.3916"/>
+            <vignetting model="pa" focal="12.6" aperture="7.1" distance="1000" k1="-0.4086" k2="1.5596" k3="-1.3916"/>
+            <vignetting model="pa" focal="12.6" aperture="8" distance="10" k1="-0.4083" k2="1.5588" k3="-1.3908"/>
+            <vignetting model="pa" focal="12.6" aperture="8" distance="1000" k1="-0.4083" k2="1.5588" k3="-1.3908"/>
+            <vignetting model="pa" focal="14.9" aperture="3.4" distance="10" k1="-0.4083" k2="1.5589" k3="-1.3909"/>
+            <vignetting model="pa" focal="14.9" aperture="3.4" distance="1000" k1="-0.4083" k2="1.5589" k3="-1.3909"/>
+            <vignetting model="pa" focal="14.9" aperture="3.5" distance="10" k1="-0.4084" k2="1.5590" k3="-1.3910"/>
+            <vignetting model="pa" focal="14.9" aperture="3.5" distance="1000" k1="-0.4084" k2="1.5590" k3="-1.3910"/>
+            <vignetting model="pa" focal="14.9" aperture="4" distance="10" k1="-0.4083" k2="1.5588" k3="-1.3908"/>
+            <vignetting model="pa" focal="14.9" aperture="4" distance="1000" k1="-0.4083" k2="1.5588" k3="-1.3908"/>
+            <vignetting model="pa" focal="14.9" aperture="4.4" distance="10" k1="-0.4084" k2="1.5591" k3="-1.3911"/>
+            <vignetting model="pa" focal="14.9" aperture="4.4" distance="1000" k1="-0.4084" k2="1.5591" k3="-1.3911"/>
+            <vignetting model="pa" focal="14.9" aperture="5" distance="10" k1="-0.4084" k2="1.5591" k3="-1.3912"/>
+            <vignetting model="pa" focal="14.9" aperture="5" distance="1000" k1="-0.4084" k2="1.5591" k3="-1.3912"/>
+            <vignetting model="pa" focal="14.9" aperture="5.6" distance="10" k1="-0.4084" k2="1.5588" k3="-1.3909"/>
+            <vignetting model="pa" focal="14.9" aperture="5.6" distance="1000" k1="-0.4084" k2="1.5588" k3="-1.3909"/>
+            <vignetting model="pa" focal="14.9" aperture="6.3" distance="10" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="14.9" aperture="6.3" distance="1000" k1="-0.4085" k2="1.5594" k3="-1.3914"/>
+            <vignetting model="pa" focal="14.9" aperture="7.1" distance="10" k1="-0.4084" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="14.9" aperture="7.1" distance="1000" k1="-0.4084" k2="1.5592" k3="-1.3912"/>
+            <vignetting model="pa" focal="14.9" aperture="8" distance="10" k1="-0.4087" k2="1.5599" k3="-1.3918"/>
+            <vignetting model="pa" focal="14.9" aperture="8" distance="1000" k1="-0.4087" k2="1.5599" k3="-1.3918"/>
+            <vignetting model="pa" focal="17.3" aperture="3.5" distance="10" k1="-0.4086" k2="1.5595" k3="-1.3913"/>
+            <vignetting model="pa" focal="17.3" aperture="3.5" distance="1000" k1="-0.4086" k2="1.5595" k3="-1.3913"/>
+            <vignetting model="pa" focal="17.3" aperture="4" distance="10" k1="-0.4087" k2="1.5600" k3="-1.3917"/>
+            <vignetting model="pa" focal="17.3" aperture="4" distance="1000" k1="-0.4087" k2="1.5600" k3="-1.3917"/>
+            <vignetting model="pa" focal="17.3" aperture="4.4" distance="10" k1="-0.4087" k2="1.5596" k3="-1.3914"/>
+            <vignetting model="pa" focal="17.3" aperture="4.4" distance="1000" k1="-0.4087" k2="1.5596" k3="-1.3914"/>
+            <vignetting model="pa" focal="17.3" aperture="5" distance="10" k1="-0.4089" k2="1.5602" k3="-1.3918"/>
+            <vignetting model="pa" focal="17.3" aperture="5" distance="1000" k1="-0.4089" k2="1.5602" k3="-1.3918"/>
+            <vignetting model="pa" focal="17.3" aperture="5.6" distance="10" k1="-0.4084" k2="1.5588" k3="-1.3907"/>
+            <vignetting model="pa" focal="17.3" aperture="5.6" distance="1000" k1="-0.4084" k2="1.5588" k3="-1.3907"/>
+            <vignetting model="pa" focal="17.3" aperture="6.3" distance="10" k1="-0.4085" k2="1.5590" k3="-1.3908"/>
+            <vignetting model="pa" focal="17.3" aperture="6.3" distance="1000" k1="-0.4085" k2="1.5590" k3="-1.3908"/>
+            <vignetting model="pa" focal="17.3" aperture="7.1" distance="10" k1="-0.4087" k2="1.5596" k3="-1.3914"/>
+            <vignetting model="pa" focal="17.3" aperture="7.1" distance="1000" k1="-0.4087" k2="1.5596" k3="-1.3914"/>
+            <vignetting model="pa" focal="17.3" aperture="8" distance="10" k1="-0.4086" k2="1.5596" k3="-1.3913"/>
+            <vignetting model="pa" focal="17.3" aperture="8" distance="1000" k1="-0.4086" k2="1.5596" k3="-1.3913"/>
+            <vignetting model="pa" focal="21.7" aperture="3.8" distance="10" k1="-0.4089" k2="1.5591" k3="-1.3907"/>
+            <vignetting model="pa" focal="21.7" aperture="3.8" distance="1000" k1="-0.4089" k2="1.5591" k3="-1.3907"/>
+            <vignetting model="pa" focal="21.7" aperture="4" distance="10" k1="-0.4090" k2="1.5595" k3="-1.3911"/>
+            <vignetting model="pa" focal="21.7" aperture="4" distance="1000" k1="-0.4090" k2="1.5595" k3="-1.3911"/>
+            <vignetting model="pa" focal="21.7" aperture="4.4" distance="10" k1="-0.4085" k2="1.5582" k3="-1.3901"/>
+            <vignetting model="pa" focal="21.7" aperture="4.4" distance="1000" k1="-0.4085" k2="1.5582" k3="-1.3901"/>
+            <vignetting model="pa" focal="21.7" aperture="5" distance="10" k1="-0.4086" k2="1.5584" k3="-1.3902"/>
+            <vignetting model="pa" focal="21.7" aperture="5" distance="1000" k1="-0.4086" k2="1.5584" k3="-1.3902"/>
+            <vignetting model="pa" focal="21.7" aperture="5.6" distance="10" k1="-0.4086" k2="1.5585" k3="-1.3903"/>
+            <vignetting model="pa" focal="21.7" aperture="5.6" distance="1000" k1="-0.4086" k2="1.5585" k3="-1.3903"/>
+            <vignetting model="pa" focal="21.7" aperture="6.3" distance="10" k1="-0.4088" k2="1.5588" k3="-1.3905"/>
+            <vignetting model="pa" focal="21.7" aperture="6.3" distance="1000" k1="-0.4088" k2="1.5588" k3="-1.3905"/>
+            <vignetting model="pa" focal="21.7" aperture="7.1" distance="10" k1="-0.4089" k2="1.5591" k3="-1.3908"/>
+            <vignetting model="pa" focal="21.7" aperture="7.1" distance="1000" k1="-0.4089" k2="1.5591" k3="-1.3908"/>
+            <vignetting model="pa" focal="21.7" aperture="8" distance="10" k1="-0.4087" k2="1.5587" k3="-1.3905"/>
+            <vignetting model="pa" focal="21.7" aperture="8" distance="1000" k1="-0.4087" k2="1.5587" k3="-1.3905"/>
+            <vignetting model="pa" focal="29.2" aperture="4.2" distance="10" k1="-0.4098" k2="1.5606" k3="-1.3914"/>
+            <vignetting model="pa" focal="29.2" aperture="4.2" distance="1000" k1="-0.4098" k2="1.5606" k3="-1.3914"/>
+            <vignetting model="pa" focal="29.2" aperture="4.4" distance="10" k1="-0.4099" k2="1.5607" k3="-1.3914"/>
+            <vignetting model="pa" focal="29.2" aperture="4.4" distance="1000" k1="-0.4099" k2="1.5607" k3="-1.3914"/>
+            <vignetting model="pa" focal="29.2" aperture="5" distance="10" k1="-0.4099" k2="1.5613" k3="-1.3919"/>
+            <vignetting model="pa" focal="29.2" aperture="5" distance="1000" k1="-0.4099" k2="1.5613" k3="-1.3919"/>
+            <vignetting model="pa" focal="29.2" aperture="5.6" distance="10" k1="-0.4095" k2="1.5596" k3="-1.3906"/>
+            <vignetting model="pa" focal="29.2" aperture="5.6" distance="1000" k1="-0.4095" k2="1.5596" k3="-1.3906"/>
+            <vignetting model="pa" focal="29.2" aperture="6.3" distance="10" k1="-0.4096" k2="1.5602" k3="-1.3911"/>
+            <vignetting model="pa" focal="29.2" aperture="6.3" distance="1000" k1="-0.4096" k2="1.5602" k3="-1.3911"/>
+            <vignetting model="pa" focal="29.2" aperture="7.1" distance="10" k1="-0.4099" k2="1.5615" k3="-1.3922"/>
+            <vignetting model="pa" focal="29.2" aperture="7.1" distance="1000" k1="-0.4099" k2="1.5615" k3="-1.3922"/>
+            <vignetting model="pa" focal="29.2" aperture="8" distance="10" k1="-0.4094" k2="1.5597" k3="-1.3907"/>
+            <vignetting model="pa" focal="29.2" aperture="8" distance="1000" k1="-0.4094" k2="1.5597" k3="-1.3907"/>
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Canon</maker>
         <model>Canon PowerShot A510 &amp; compatibles (Standard)</model>
         <model lang="en">fixed lens</model>
         <model lang="de">festes Objektiv</model>


### PR DESCRIPTION
Full profiling (distortion, tca, vignetting) done on a PowerShot A620 (same lens as A610) using CHDK DNG files. This covers all 9 zoom steps, which can be selected in CHDKs uBasic.