### PR TITLE
Add vignetting data for Canon EF 24-70mm f/4L IS USM

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -4993,6 +4993,57 @@
             <tca model="poly3" focal="42" br="-0.0000549" vr="1.0000990" bb="0.0000341" vb="0.9999984"/>
             <tca model="poly3" focal="50" br="-0.0000538" vr="1.0000124" bb="0.0000396" vb="1.0000021"/>
             <tca model="poly3" focal="70" br="-0.0000278" vr="0.9998685" bb="0.0000294" vb="0.9999997"/>
+            <!-- Taken with Canon EOS 6D -->
+            <vignetting model="pa" focal="24" aperture="4" distance="10" k1="-0.1615" k2="-1.1713" k3="0.6378" />
+            <vignetting model="pa" focal="24" aperture="4" distance="1000" k1="-0.1615" k2="-1.1713" k3="0.6378" />
+            <vignetting model="pa" focal="24" aperture="5.6" distance="10" k1="-0.3982" k2="-0.0498" k3="-0.1606" />
+            <vignetting model="pa" focal="24" aperture="5.6" distance="1000" k1="-0.3982" k2="-0.0498" k3="-0.1606" />
+            <vignetting model="pa" focal="24" aperture="8" distance="10" k1="-0.5970" k2="0.6157" k3="-0.5651" />
+            <vignetting model="pa" focal="24" aperture="8" distance="1000" k1="-0.5970" k2="0.6157" k3="-0.5651" />
+            <vignetting model="pa" focal="24" aperture="11" distance="10" k1="-0.6115" k2="0.5818" k3="-0.4343" />
+            <vignetting model="pa" focal="24" aperture="11" distance="1000" k1="-0.6115" k2="0.5818" k3="-0.4343" />
+            <vignetting model="pa" focal="24" aperture="22" distance="10" k1="-0.4913" k2="0.0981" k3="0.0087" />
+            <vignetting model="pa" focal="24" aperture="22" distance="1000" k1="-0.4913" k2="0.0981" k3="0.0087" />
+            <vignetting model="pa" focal="35" aperture="4" distance="10" k1="-0.4223" k2="-0.5202" k3="0.4288" />
+            <vignetting model="pa" focal="35" aperture="4" distance="1000" k1="-0.4223" k2="-0.5202" k3="0.4288" />
+            <vignetting model="pa" focal="35" aperture="5.6" distance="10" k1="-0.3922" k2="0.1260" k3="-0.0575" />
+            <vignetting model="pa" focal="35" aperture="5.6" distance="1000" k1="-0.3922" k2="0.1260" k3="-0.0575" />
+            <vignetting model="pa" focal="35" aperture="8" distance="10" k1="-0.3842" k2="0.0713" k3="0.0195" />
+            <vignetting model="pa" focal="35" aperture="8" distance="1000" k1="-0.3842" k2="0.0713" k3="0.0195" />
+            <vignetting model="pa" focal="35" aperture="11" distance="10" k1="-0.3857" k2="0.0737" k3="0.0193" />
+            <vignetting model="pa" focal="35" aperture="11" distance="1000" k1="-0.3857" k2="0.0737" k3="0.0193" />
+            <vignetting model="pa" focal="35" aperture="22" distance="10" k1="-0.3801" k2="0.0557" k3="0.0315" />
+            <vignetting model="pa" focal="35" aperture="22" distance="1000" k1="-0.3801" k2="0.0557" k3="0.0315" />
+            <vignetting model="pa" focal="45" aperture="4" distance="10" k1="-0.7061" k2="-0.0355" k3="0.2001" />
+            <vignetting model="pa" focal="45" aperture="4" distance="1000" k1="-0.7061" k2="-0.0355" k3="0.2001" />
+            <vignetting model="pa" focal="45" aperture="5.6" distance="10" k1="-0.3253" k2="0.0580" k3="-0.0546" />
+            <vignetting model="pa" focal="45" aperture="5.6" distance="1000" k1="-0.3253" k2="0.0580" k3="-0.0546" />
+            <vignetting model="pa" focal="45" aperture="8" distance="10" k1="-0.3470" k2="0.0840" k3="0.0080" />
+            <vignetting model="pa" focal="45" aperture="8" distance="1000" k1="-0.3470" k2="0.0840" k3="0.0080" />
+            <vignetting model="pa" focal="45" aperture="11" distance="10" k1="-0.3482" k2="0.0836" k3="0.0097" />
+            <vignetting model="pa" focal="45" aperture="11" distance="1000" k1="-0.3482" k2="0.0836" k3="0.0097" />
+            <vignetting model="pa" focal="45" aperture="22" distance="10" k1="-0.3432" k2="0.0681" k3="0.0205" />
+            <vignetting model="pa" focal="45" aperture="22" distance="1000" k1="-0.3432" k2="0.0681" k3="0.0205" />
+            <vignetting model="pa" focal="57" aperture="4" distance="10" k1="-1.1430" k2="1.0845" k3="-0.5956" />
+            <vignetting model="pa" focal="57" aperture="4" distance="1000" k1="-1.1430" k2="1.0845" k3="-0.5956" />
+            <vignetting model="pa" focal="57" aperture="5.6" distance="10" k1="-0.4146" k2="0.5478" k3="-0.5451" />
+            <vignetting model="pa" focal="57" aperture="5.6" distance="1000" k1="-0.4146" k2="0.5478" k3="-0.5451" />
+            <vignetting model="pa" focal="57" aperture="8" distance="10" k1="-0.3612" k2="0.2531" k3="-0.1443" />
+            <vignetting model="pa" focal="57" aperture="8" distance="1000" k1="-0.3612" k2="0.2531" k3="-0.1443" />
+            <vignetting model="pa" focal="57" aperture="11" distance="10" k1="-0.3193" k2="0.0897" k3="0.0028" />
+            <vignetting model="pa" focal="57" aperture="11" distance="1000" k1="-0.3193" k2="0.0897" k3="0.0028" />
+            <vignetting model="pa" focal="57" aperture="22" distance="10" k1="-0.3155" k2="0.0769" k3="0.0120" />
+            <vignetting model="pa" focal="57" aperture="22" distance="1000" k1="-0.3155" k2="0.0769" k3="0.0120" />
+            <vignetting model="pa" focal="70" aperture="4" distance="10" k1="-1.4222" k2="1.7476" k3="-0.9716" />
+            <vignetting model="pa" focal="70" aperture="4" distance="1000" k1="-1.4222" k2="1.7476" k3="-0.9716" />
+            <vignetting model="pa" focal="70" aperture="5.6" distance="10" k1="-0.2987" k2="0.1781" k3="-0.3001" />
+            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="-0.2987" k2="0.1781" k3="-0.3001" />
+            <vignetting model="pa" focal="70" aperture="8" distance="10" k1="-0.3198" k2="0.2335" k3="-0.1340" />
+            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.3198" k2="0.2335" k3="-0.1340" />
+            <vignetting model="pa" focal="70" aperture="11" distance="10" k1="-0.2890" k2="0.1029" k3="-0.0126" />
+            <vignetting model="pa" focal="70" aperture="11" distance="1000" k1="-0.2890" k2="0.1029" k3="-0.0126" />
+            <vignetting model="pa" focal="70" aperture="22" distance="10" k1="-0.2864" k2="0.0932" k3="-0.0051" />
+            <vignetting model="pa" focal="70" aperture="22" distance="1000" k1="-0.2864" k2="0.0932" k3="-0.0051" />
         </calibration>
     </lens>
 


### PR DESCRIPTION
The calibration data was created following this guide:
http://wilson.bronger.org/lens_calibration_tutorial/#id3