### PR TITLE
Add Nikon D5 and Nikon D500 SLRs

### DIFF
--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -163,6 +163,15 @@
     <camera>
         <maker>Nikon Corporation</maker>
         <maker lang="en">Nikon</maker>
+        <model>Nikon D500</model>
+        <model lang="en">D500</model>
+        <mount>Nikon F AF</mount>
+        <cropfactor>1.531</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Nikon Corporation</maker>
+        <maker lang="en">Nikon</maker>
         <model>Nikon D600</model>
         <model lang="en">D600</model>
         <mount>Nikon F AF</mount>
@@ -437,6 +446,15 @@
         <model lang="en">D4s</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Nikon Corporation</maker>
+        <maker lang="en">Nikon</maker>
+        <model>Nikon D5</model>
+        <model lang="en">D5</model>
+        <mount>Nikon F AF</mount>
+        <cropfactor>1.003</cropfactor>
     </camera>
 
     <camera>


### PR DESCRIPTION
D5 sensor size: 35.9mm x 23.9mm
D500 sensor size: 23.5mm x 15.7mm