### PR TITLE
Simplify the data for Canon EF 50mm f/1.8 II

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -3143,19 +3143,8 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>Canon EF 50mm f/1.8 II</model>
-        <mount>Canon EF</mount>
-        <!-- Average crop factor of Canon APS-C cameras -->
-        <cropfactor>1.611</cropfactor>
-        <calibration>
-            <distortion model="ptlens" focal="50" a="0.00099" b="-0.00582" c="0.00498"/>
-            <tca model="poly3" focal="50" br="-0.0000133" vr="1.0001567" bb="-0.0000082" vb="0.9999807"/>
-        </calibration>
-    </lens>
-
-    <lens>
-        <maker>Canon</maker>
-        <model>Canon EF 50mm f/1.8 II</model>
+        <model>Canon EF 50mm f/1.8 MkII</model>
+        <model lang="en">Canon EF 50mm f/1.8 II</model>
         <mount>Canon EF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3203,9 +3192,10 @@
         <mount>Canon EF</mount>
         <cropfactor>1.622</cropfactor>
         <calibration>
-            <!-- Taken with cropfactor 1.622 (Canon 50D or 450D) -->
+            <!-- Taken with generic Canon APS-C (avg crop 1.611) -->
             <distortion a="0.00099" b="-0.00582" c="0.00498" focal="50" model="ptlens"/>
             <tca bb="-0.0000082" br="-0.0000133" focal="50" model="poly3" vb="0.9999807" vr="1.0001567"/>
+            <!-- Taken with cropfactor 1.622 (Canon 50D or 450D) -->
             <vignetting model="pa" focal="50" aperture="1.8" distance="0.45" k1="-0.5303" k2="0.3040" k3="-0.0894"/>
             <vignetting model="pa" focal="50" aperture="1.8" distance="1000" k1="-0.6075" k2="0.4041" k3="-0.1510"/>
             <vignetting model="pa" focal="50" aperture="2" distance="0.45" k1="-0.1253" k2="-0.3078" k3="0.2075"/>


### PR DESCRIPTION
Change so that the name is given consistently for all crop factors and combine
the two entries for APS-C that arose from a misunderstanding.

The entry with crop factor 1.622 was created by me adding vignetting data and copies the other data from the other entry. (The crop factors all just said 1.6 when I created them because of an old database so the difference didn't show up). Having both copies seems wrong but removing entries from the database worries me.

I also changed the one inconsistent copy of the name of the lens to match the other two, so that the matching is consistent across camera models. This seems undesirable but I have no evidence that it's actually a problem for anyone.