### PR TITLE
Redo some Sony vignetting data, add FE 1.8/85.

### DIFF
--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -804,75 +804,108 @@
             <tca model="poly3" focal="50" br="-0.0000632" vr="1.0003667" bb="0.0000586" vb="0.9998070"/>
             <tca model="poly3" focal="60" br="-0.0000295" vr="1.0003004" bb="0.0000423" vb="0.9997824"/>
             <tca model="poly3" focal="70" br="-0.0000446" vr="1.0002475" bb="0.0000515" vb="0.9998071"/>
-            <vignetting model="pa" focal="28" aperture="3.5" distance="10" k1="-0.9958" k2="0.6715" k3="-0.2346"/>
-            <vignetting model="pa" focal="28" aperture="3.5" distance="1000" k1="-0.9958" k2="0.6715" k3="-0.2346"/>
-            <vignetting model="pa" focal="28" aperture="4.5" distance="10" k1="-0.8656" k2="0.4586" k3="-0.1295"/>
-            <vignetting model="pa" focal="28" aperture="4.5" distance="1000" k1="-0.8656" k2="0.4586" k3="-0.1295"/>
-            <vignetting model="pa" focal="33" aperture="4" distance="10" k1="-0.6549" k2="0.0647" k3="0.1034"/>
-            <vignetting model="pa" focal="33" aperture="4" distance="1000" k1="-0.6549" k2="0.0647" k3="0.1034"/>
-            <vignetting model="pa" focal="34" aperture="4" distance="10" k1="-0.6043" k2="-0.0372" k3="0.1663"/>
-            <vignetting model="pa" focal="34" aperture="4" distance="1000" k1="-0.6043" k2="-0.0372" k3="0.1663"/>
-            <vignetting model="pa" focal="35" aperture="4" distance="10" k1="-0.6119" k2="-0.0377" k3="0.1734"/>
-            <vignetting model="pa" focal="35" aperture="4" distance="1000" k1="-0.6119" k2="-0.0377" k3="0.1734"/>
-            <vignetting model="pa" focal="43" aperture="4.5" distance="10" k1="-0.6179" k2="0.1041" k3="0.0656"/>
-            <vignetting model="pa" focal="43" aperture="4.5" distance="1000" k1="-0.6179" k2="0.1041" k3="0.0656"/>
-            <vignetting model="pa" focal="50" aperture="4.5" distance="10" k1="-0.5598" k2="0.0335" k3="0.1017"/>
-            <vignetting model="pa" focal="50" aperture="4.5" distance="1000" k1="-0.5598" k2="0.0335" k3="0.1017"/>
-            <vignetting model="pa" focal="59" aperture="5" distance="10" k1="-0.5872" k2="0.1618" k3="0.0081"/>
-            <vignetting model="pa" focal="59" aperture="5" distance="1000" k1="-0.5872" k2="0.1618" k3="0.0081"/>
-            <vignetting model="pa" focal="61" aperture="5.6" distance="10" k1="-0.5783" k2="0.1194" k3="0.0436"/>
-            <vignetting model="pa" focal="61" aperture="5.6" distance="1000" k1="-0.5783" k2="0.1194" k3="0.0436"/>
-            <vignetting model="pa" focal="70" aperture="5.6" distance="10" k1="-0.6097" k2="0.2252" k3="-0.0272"/>
-            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="-0.6097" k2="0.2252" k3="-0.0272"/>
-            <!-- Taken with Sony A7R -->
-            <vignetting model="pa" focal="28" aperture="5.6" distance="10" k1="-0.6402" k2="0.1132" k3="0.0503"/>
-            <vignetting model="pa" focal="28" aperture="5.6" distance="1000" k1="-0.6402" k2="0.1132" k3="0.0503"/>
-            <vignetting model="pa" focal="28" aperture="8" distance="10" k1="-0.5912" k2="0.1955" k3="-0.0733"/>
-            <vignetting model="pa" focal="28" aperture="8" distance="1000" k1="-0.5912" k2="0.1955" k3="-0.0733"/>
-            <vignetting model="pa" focal="28" aperture="11" distance="10" k1="-0.6687" k2="0.2261" k3="-0.0237"/>
-            <vignetting model="pa" focal="28" aperture="11" distance="1000" k1="-0.6687" k2="0.2261" k3="-0.0237"/>
-            <vignetting model="pa" focal="28" aperture="16" distance="10" k1="-0.6727" k2="0.2317" k3="-0.0267"/>
-            <vignetting model="pa" focal="28" aperture="16" distance="1000" k1="-0.6727" k2="0.2317" k3="-0.0267"/>
-            <vignetting model="pa" focal="28" aperture="22" distance="10" k1="-0.6821" k2="0.2473" k3="-0.0350"/>
-            <vignetting model="pa" focal="28" aperture="22" distance="1000" k1="-0.6821" k2="0.2473" k3="-0.0350"/>
-            <vignetting model="pa" focal="39" aperture="5.6" distance="10" k1="-0.5096" k2="-0.1688" k3="0.2299"/>
-            <vignetting model="pa" focal="39" aperture="5.6" distance="1000" k1="-0.5096" k2="-0.1688" k3="0.2299"/>
-            <vignetting model="pa" focal="39" aperture="8" distance="10" k1="-0.5198" k2="0.1033" k3="-0.0344"/>
-            <vignetting model="pa" focal="39" aperture="8" distance="1000" k1="-0.5198" k2="0.1033" k3="-0.0344"/>
-            <vignetting model="pa" focal="39" aperture="11" distance="10" k1="-0.5785" k2="0.1391" k3="0.0072"/>
-            <vignetting model="pa" focal="39" aperture="11" distance="1000" k1="-0.5785" k2="0.1391" k3="0.0072"/>
-            <vignetting model="pa" focal="39" aperture="16" distance="10" k1="-0.5807" k2="0.1393" k3="0.0100"/>
-            <vignetting model="pa" focal="39" aperture="16" distance="1000" k1="-0.5807" k2="0.1393" k3="0.0100"/>
-            <vignetting model="pa" focal="39" aperture="22" distance="10" k1="-0.5850" k2="0.1455" k3="0.0072"/>
-            <vignetting model="pa" focal="39" aperture="22" distance="1000" k1="-0.5850" k2="0.1455" k3="0.0072"/>
-            <vignetting model="pa" focal="50" aperture="5.6" distance="10" k1="-0.4237" k2="-0.2290" k3="0.2233"/>
-            <vignetting model="pa" focal="50" aperture="5.6" distance="1000" k1="-0.4237" k2="-0.2290" k3="0.2233"/>
-            <vignetting model="pa" focal="50" aperture="8" distance="10" k1="-0.2528" k2="-0.2318" k3="0.0530"/>
-            <vignetting model="pa" focal="50" aperture="8" distance="1000" k1="-0.2528" k2="-0.2318" k3="0.0530"/>
-            <vignetting model="pa" focal="50" aperture="11" distance="10" k1="-0.5421" k2="0.2468" k3="-0.1244"/>
-            <vignetting model="pa" focal="50" aperture="11" distance="1000" k1="-0.5421" k2="0.2468" k3="-0.1244"/>
-            <vignetting model="pa" focal="50" aperture="16" distance="10" k1="-0.5062" k2="0.0951" k3="0.0183"/>
-            <vignetting model="pa" focal="50" aperture="16" distance="1000" k1="-0.5062" k2="0.0951" k3="0.0183"/>
-            <vignetting model="pa" focal="50" aperture="22" distance="10" k1="-0.5067" k2="0.0943" k3="0.0197"/>
-            <vignetting model="pa" focal="50" aperture="22" distance="1000" k1="-0.5067" k2="0.0943" k3="0.0197"/>
-            <vignetting model="pa" focal="58" aperture="5.6" distance="10" k1="-0.4700" k2="-0.1909" k3="0.2551"/>
-            <vignetting model="pa" focal="58" aperture="5.6" distance="1000" k1="-0.4700" k2="-0.1909" k3="0.2551"/>
-            <vignetting model="pa" focal="58" aperture="8" distance="10" k1="-0.2142" k2="-0.3229" k3="0.1187"/>
-            <vignetting model="pa" focal="58" aperture="8" distance="1000" k1="-0.2142" k2="-0.3229" k3="0.1187"/>
-            <vignetting model="pa" focal="58" aperture="11" distance="10" k1="-0.4904" k2="0.2571" k3="-0.1702"/>
-            <vignetting model="pa" focal="58" aperture="11" distance="1000" k1="-0.4904" k2="0.2571" k3="-0.1702"/>
-            <vignetting model="pa" focal="58" aperture="16" distance="10" k1="-0.4496" k2="0.0645" k3="0.0256"/>
-            <vignetting model="pa" focal="58" aperture="16" distance="1000" k1="-0.4496" k2="0.0645" k3="0.0256"/>
-            <vignetting model="pa" focal="58" aperture="22" distance="10" k1="-0.4532" k2="0.0707" k3="0.0230"/>
-            <vignetting model="pa" focal="58" aperture="22" distance="1000" k1="-0.4532" k2="0.0707" k3="0.0230"/>
-            <vignetting model="pa" focal="70" aperture="8" distance="10" k1="-0.1553" k2="-0.4531" k3="0.2001"/>
-            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.1553" k2="-0.4531" k3="0.2001"/>
-            <vignetting model="pa" focal="70" aperture="11" distance="10" k1="-0.2888" k2="-0.0086" k3="-0.0454"/>
-            <vignetting model="pa" focal="70" aperture="11" distance="1000" k1="-0.2888" k2="-0.0086" k3="-0.0454"/>
-            <vignetting model="pa" focal="70" aperture="16" distance="10" k1="-0.4226" k2="0.1136" k3="-0.0383"/>
-            <vignetting model="pa" focal="70" aperture="16" distance="1000" k1="-0.4226" k2="0.1136" k3="-0.0383"/>
-            <vignetting model="pa" focal="70" aperture="22" distance="10" k1="-0.4057" k2="0.0361" k3="0.0339"/>
-            <vignetting model="pa" focal="70" aperture="22" distance="1000" k1="-0.4057" k2="0.0361" k3="0.0339"/>
+            <vignetting model="pa" focal="28" aperture="3.5" distance="10" k1="-1.2040" k2="0.7047" k3="-0.2263"/>
+            <vignetting model="pa" focal="28" aperture="3.5" distance="1000" k1="-1.2040" k2="0.7047" k3="-0.2263"/>
+            <vignetting model="pa" focal="28" aperture="4" distance="10" k1="-0.6285" k2="-0.2594" k3="0.2262"/>
+            <vignetting model="pa" focal="28" aperture="4" distance="1000" k1="-0.6285" k2="-0.2594" k3="0.2262"/>
+            <vignetting model="pa" focal="28" aperture="4.5" distance="10" k1="-0.4980" k2="-0.3476" k3="0.2322"/>
+            <vignetting model="pa" focal="28" aperture="4.5" distance="1000" k1="-0.4980" k2="-0.3476" k3="0.2322"/>
+            <vignetting model="pa" focal="28" aperture="5" distance="10" k1="-0.4633" k2="-0.2486" k3="0.1501"/>
+            <vignetting model="pa" focal="28" aperture="5" distance="1000" k1="-0.4633" k2="-0.2486" k3="0.1501"/>
+            <vignetting model="pa" focal="28" aperture="5.6" distance="10" k1="-0.5125" k2="-0.0137" k3="0.0056"/>
+            <vignetting model="pa" focal="28" aperture="5.6" distance="1000" k1="-0.5125" k2="-0.0137" k3="0.0056"/>
+            <vignetting model="pa" focal="28" aperture="8" distance="10" k1="-0.6026" k2="0.2287" k3="-0.0677"/>
+            <vignetting model="pa" focal="28" aperture="8" distance="1000" k1="-0.6026" k2="0.2287" k3="-0.0677"/>
+            <vignetting model="pa" focal="28" aperture="11" distance="10" k1="-0.5856" k2="0.1429" k3="0.0134"/>
+            <vignetting model="pa" focal="28" aperture="11" distance="1000" k1="-0.5856" k2="0.1429" k3="0.0134"/>
+            <vignetting model="pa" focal="28" aperture="16" distance="10" k1="-0.6349" k2="0.2384" k3="-0.0403"/>
+            <vignetting model="pa" focal="28" aperture="16" distance="1000" k1="-0.6349" k2="0.2384" k3="-0.0403"/>
+            <vignetting model="pa" focal="28" aperture="22" distance="10" k1="-0.5911" k2="0.1506" k3="0.0138"/>
+            <vignetting model="pa" focal="28" aperture="22" distance="1000" k1="-0.5911" k2="0.1506" k3="0.0138"/>
+            <vignetting model="pa" focal="33" aperture="4" distance="10" k1="-0.7101" k2="-0.3088" k3="0.3942"/>
+            <vignetting model="pa" focal="33" aperture="4" distance="1000" k1="-0.7101" k2="-0.3088" k3="0.3942"/>
+            <vignetting model="pa" focal="33" aperture="4.5" distance="10" k1="-0.4120" k2="-0.6673" k3="0.5188"/>
+            <vignetting model="pa" focal="33" aperture="4.5" distance="1000" k1="-0.4120" k2="-0.6673" k3="0.5188"/>
+            <vignetting model="pa" focal="33" aperture="5" distance="10" k1="-0.3687" k2="-0.5405" k3="0.3704"/>
+            <vignetting model="pa" focal="33" aperture="5" distance="1000" k1="-0.3687" k2="-0.5405" k3="0.3704"/>
+            <vignetting model="pa" focal="33" aperture="5.6" distance="10" k1="-0.4116" k2="-0.2658" k3="0.1587"/>
+            <vignetting model="pa" focal="33" aperture="5.6" distance="1000" k1="-0.4116" k2="-0.2658" k3="0.1587"/>
+            <vignetting model="pa" focal="33" aperture="6.3" distance="10" k1="-0.4848" k2="0.0339" k3="-0.0425"/>
+            <vignetting model="pa" focal="33" aperture="6.3" distance="1000" k1="-0.4848" k2="0.0339" k3="-0.0425"/>
+            <vignetting model="pa" focal="33" aperture="7.1" distance="10" k1="-0.5449" k2="0.2203" k3="-0.1436"/>
+            <vignetting model="pa" focal="33" aperture="7.1" distance="1000" k1="-0.5449" k2="0.2203" k3="-0.1436"/>
+            <vignetting model="pa" focal="33" aperture="8" distance="10" k1="-0.5616" k2="0.2365" k3="-0.1116"/>
+            <vignetting model="pa" focal="33" aperture="8" distance="1000" k1="-0.5616" k2="0.2365" k3="-0.1116"/>
+            <vignetting model="pa" focal="33" aperture="11" distance="10" k1="-0.5240" k2="0.0826" k3="0.0352"/>
+            <vignetting model="pa" focal="33" aperture="11" distance="1000" k1="-0.5240" k2="0.0826" k3="0.0352"/>
+            <vignetting model="pa" focal="33" aperture="16" distance="10" k1="-0.5459" k2="0.1207" k3="0.0161"/>
+            <vignetting model="pa" focal="33" aperture="16" distance="1000" k1="-0.5459" k2="0.1207" k3="0.0161"/>
+            <vignetting model="pa" focal="33" aperture="22" distance="10" k1="-0.5583" k2="0.1451" k3="0.0014"/>
+            <vignetting model="pa" focal="33" aperture="22" distance="1000" k1="-0.5583" k2="0.1451" k3="0.0014"/>
+            <vignetting model="pa" focal="33" aperture="25" distance="10" k1="-0.5638" k2="0.1568" k3="-0.0058"/>
+            <vignetting model="pa" focal="33" aperture="25" distance="1000" k1="-0.5638" k2="0.1568" k3="-0.0058"/>
+            <vignetting model="pa" focal="50" aperture="4.5" distance="10" k1="-0.6196" k2="-0.3001" k3="0.3240"/>
+            <vignetting model="pa" focal="50" aperture="4.5" distance="1000" k1="-0.6196" k2="-0.3001" k3="0.3240"/>
+            <vignetting model="pa" focal="50" aperture="5" distance="10" k1="-0.4522" k2="-0.5970" k3="0.4794"/>
+            <vignetting model="pa" focal="50" aperture="5" distance="1000" k1="-0.4522" k2="-0.5970" k3="0.4794"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="10" k1="-0.2762" k2="-0.8020" k3="0.5354"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="1000" k1="-0.2762" k2="-0.8020" k3="0.5354"/>
+            <vignetting model="pa" focal="50" aperture="6.3" distance="10" k1="-0.2920" k2="-0.5531" k3="0.3211"/>
+            <vignetting model="pa" focal="50" aperture="6.3" distance="1000" k1="-0.2920" k2="-0.5531" k3="0.3211"/>
+            <vignetting model="pa" focal="50" aperture="7.1" distance="10" k1="-0.3606" k2="-0.2187" k3="0.0762"/>
+            <vignetting model="pa" focal="50" aperture="7.1" distance="1000" k1="-0.3606" k2="-0.2187" k3="0.0762"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="10" k1="-0.4506" k2="0.1175" k3="-0.1429"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="1000" k1="-0.4506" k2="0.1175" k3="-0.1429"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="10" k1="-0.5004" k2="0.2186" k3="-0.1088"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="1000" k1="-0.5004" k2="0.2186" k3="-0.1088"/>
+            <vignetting model="pa" focal="50" aperture="16" distance="10" k1="-0.4597" k2="0.0602" k3="0.0335"/>
+            <vignetting model="pa" focal="50" aperture="16" distance="1000" k1="-0.4597" k2="0.0602" k3="0.0335"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="10" k1="-0.4545" k2="0.0424" k3="0.0466"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="1000" k1="-0.4545" k2="0.0424" k3="0.0466"/>
+            <vignetting model="pa" focal="50" aperture="32" distance="10" k1="-0.4673" k2="0.0739" k3="0.0272"/>
+            <vignetting model="pa" focal="50" aperture="32" distance="1000" k1="-0.4673" k2="0.0739" k3="0.0272"/>
+            <vignetting model="pa" focal="56" aperture="5" distance="10" k1="-0.6399" k2="-0.1617" k3="0.2205"/>
+            <vignetting model="pa" focal="56" aperture="5" distance="1000" k1="-0.6399" k2="-0.1617" k3="0.2205"/>
+            <vignetting model="pa" focal="56" aperture="5.6" distance="10" k1="-0.2641" k2="-0.8424" k3="0.5716"/>
+            <vignetting model="pa" focal="56" aperture="5.6" distance="1000" k1="-0.2641" k2="-0.8424" k3="0.5716"/>
+            <vignetting model="pa" focal="56" aperture="6.3" distance="10" k1="-0.2242" k2="-0.7338" k3="0.4420"/>
+            <vignetting model="pa" focal="56" aperture="6.3" distance="1000" k1="-0.2242" k2="-0.7338" k3="0.4420"/>
+            <vignetting model="pa" focal="56" aperture="7.1" distance="10" k1="-0.2874" k2="-0.3743" k3="0.1669"/>
+            <vignetting model="pa" focal="56" aperture="7.1" distance="1000" k1="-0.2874" k2="-0.3743" k3="0.1669"/>
+            <vignetting model="pa" focal="56" aperture="8" distance="10" k1="-0.3831" k2="0.0014" k3="-0.0863"/>
+            <vignetting model="pa" focal="56" aperture="8" distance="1000" k1="-0.3831" k2="0.0014" k3="-0.0863"/>
+            <vignetting model="pa" focal="56" aperture="9" distance="10" k1="-0.4535" k2="0.2327" k3="-0.2203"/>
+            <vignetting model="pa" focal="56" aperture="9" distance="1000" k1="-0.4535" k2="0.2327" k3="-0.2203"/>
+            <vignetting model="pa" focal="56" aperture="11" distance="10" k1="-0.4956" k2="0.3037" k3="-0.1913"/>
+            <vignetting model="pa" focal="56" aperture="11" distance="1000" k1="-0.4956" k2="0.3037" k3="-0.1913"/>
+            <vignetting model="pa" focal="56" aperture="16" distance="10" k1="-0.4425" k2="0.0859" k3="0.0110"/>
+            <vignetting model="pa" focal="56" aperture="16" distance="1000" k1="-0.4425" k2="0.0859" k3="0.0110"/>
+            <vignetting model="pa" focal="56" aperture="22" distance="10" k1="-0.4563" k2="0.1202" k3="-0.0115"/>
+            <vignetting model="pa" focal="56" aperture="22" distance="1000" k1="-0.4563" k2="0.1202" k3="-0.0115"/>
+            <vignetting model="pa" focal="56" aperture="32" distance="10" k1="-0.4627" k2="0.1356" k3="-0.0216"/>
+            <vignetting model="pa" focal="56" aperture="32" distance="1000" k1="-0.4627" k2="0.1356" k3="-0.0216"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="10" k1="-0.6069" k2="-0.1103" k3="0.1505"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="-0.6069" k2="-0.1103" k3="0.1505"/>
+            <vignetting model="pa" focal="70" aperture="6.3" distance="10" k1="-0.2376" k2="-0.8342" k3="0.5414"/>
+            <vignetting model="pa" focal="70" aperture="6.3" distance="1000" k1="-0.2376" k2="-0.8342" k3="0.5414"/>
+            <vignetting model="pa" focal="70" aperture="7.1" distance="10" k1="-0.1424" k2="-0.8532" k3="0.4849"/>
+            <vignetting model="pa" focal="70" aperture="7.1" distance="1000" k1="-0.1424" k2="-0.8532" k3="0.4849"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="10" k1="-0.2108" k2="-0.4717" k3="0.1932"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.2108" k2="-0.4717" k3="0.1932"/>
+            <vignetting model="pa" focal="70" aperture="9" distance="10" k1="-0.3057" k2="-0.0952" k3="-0.0649"/>
+            <vignetting model="pa" focal="70" aperture="9" distance="1000" k1="-0.3057" k2="-0.0952" k3="-0.0649"/>
+            <vignetting model="pa" focal="70" aperture="10" distance="10" k1="-0.3949" k2="0.2028" k3="-0.2450"/>
+            <vignetting model="pa" focal="70" aperture="10" distance="1000" k1="-0.3949" k2="0.2028" k3="-0.2450"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="10" k1="-0.4420" k2="0.3333" k3="-0.2965"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="1000" k1="-0.4420" k2="0.3333" k3="-0.2965"/>
+            <vignetting model="pa" focal="70" aperture="16" distance="10" k1="-0.4200" k2="0.1521" k3="-0.0582"/>
+            <vignetting model="pa" focal="70" aperture="16" distance="1000" k1="-0.4200" k2="0.1521" k3="-0.0582"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="10" k1="-0.4378" k2="0.1603" k3="-0.0423"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="1000" k1="-0.4378" k2="0.1603" k3="-0.0423"/>
+            <vignetting model="pa" focal="70" aperture="32" distance="10" k1="-0.4615" k2="0.2083" k3="-0.0690"/>
+            <vignetting model="pa" focal="70" aperture="32" distance="1000" k1="-0.4615" k2="0.2083" k3="-0.0690"/>
+            <vignetting model="pa" focal="70" aperture="36" distance="10" k1="-0.3423" k2="-0.0465" k3="0.0757"/>
+            <vignetting model="pa" focal="70" aperture="36" distance="1000" k1="-0.3423" k2="-0.0465" k3="0.0757"/>
         </calibration>
     </lens>
 
@@ -916,33 +949,37 @@
             <!-- Taken with Sony A7 II -->
             <distortion model="ptlens" focal="55" a="-0.01142" b="0.02682" c="-0.01628"/>
             <tca model="poly3" focal="55" vr="1.00005" vb="0.99975"/>
-            <vignetting model="pa" focal="55" aperture="1.8" distance="10" k1="-1.7122" k2="1.4630" k3="-0.5496"/>
-            <vignetting model="pa" focal="55" aperture="1.8" distance="1000" k1="-1.7122" k2="1.4630" k3="-0.5496"/>
-            <vignetting model="pa" focal="55" aperture="2" distance="10" k1="-1.0970" k2="0.1591" k3="0.1811"/>
-            <vignetting model="pa" focal="55" aperture="2" distance="1000" k1="-1.0970" k2="0.1591" k3="0.1811"/>
-            <vignetting model="pa" focal="55" aperture="2.2" distance="10" k1="-0.5114" k2="-0.7968" k3="0.6178"/>
-            <vignetting model="pa" focal="55" aperture="2.2" distance="1000" k1="-0.5114" k2="-0.7968" k3="0.6178"/>
-            <vignetting model="pa" focal="55" aperture="2.5" distance="10" k1="-0.3370" k2="-0.9220" k3="0.6109"/>
-            <vignetting model="pa" focal="55" aperture="2.5" distance="1000" k1="-0.3370" k2="-0.9220" k3="0.6109"/>
-            <vignetting model="pa" focal="55" aperture="2.8" distance="10" k1="-0.2019" k2="-0.9757" k3="0.5767"/>
-            <vignetting model="pa" focal="55" aperture="2.8" distance="1000" k1="-0.2019" k2="-0.9757" k3="0.5767"/>
-            <vignetting model="pa" focal="55" aperture="3.2" distance="10" k1="-0.2222" k2="-0.6336" k3="0.2788"/>
-            <vignetting model="pa" focal="55" aperture="3.2" distance="1000" k1="-0.2222" k2="-0.6336" k3="0.2788"/>
-            <vignetting model="pa" focal="55" aperture="3.5" distance="10" k1="-0.2874" k2="-0.2773" k3="0.0052"/>
-            <vignetting model="pa" focal="55" aperture="3.5" distance="1000" k1="-0.2874" k2="-0.2773" k3="0.0052"/>
-            <vignetting model="pa" focal="55" aperture="4" distance="10" k1="-0.3915" k2="0.1545" k3="-0.2962"/>
-            <vignetting model="pa" focal="55" aperture="4" distance="1000" k1="-0.3915" k2="0.1545" k3="-0.2962"/>
-            <vignetting model="pa" focal="55" aperture="5.6" distance="10" k1="-0.5843" k2="0.7891" k3="-0.6427"/>
-            <vignetting model="pa" focal="55" aperture="5.6" distance="1000" k1="-0.5843" k2="0.7891" k3="-0.6427"/>
-            <vignetting model="pa" focal="55" aperture="8" distance="10" k1="-0.5739" k2="0.6731" k3="-0.4594"/>
-            <vignetting model="pa" focal="55" aperture="8" distance="1000" k1="-0.5739" k2="0.6731" k3="-0.4594"/>
-            <vignetting model="pa" focal="55" aperture="11" distance="10" k1="-0.4869" k2="0.2979" k3="-0.1001"/>
-            <vignetting model="pa" focal="55" aperture="11" distance="1000" k1="-0.4869" k2="0.2979" k3="-0.1001"/>
-            <vignetting model="pa" focal="55" aperture="16" distance="10" k1="-0.4737" k2="0.2267" k3="-0.0281"/>
-            <vignetting model="pa" focal="55" aperture="16" distance="1000" k1="-0.4737" k2="0.2267" k3="-0.0281"/>
-            <vignetting model="pa" focal="55" aperture="22" distance="10" k1="-0.3082" k2="-0.0741" k3="0.1667"/>
-            <vignetting model="pa" focal="55" aperture="22" distance="1000" k1="-0.3082" k2="-0.0741" k3="0.1667"/>
-        </calibration>
+            <vignetting model="pa" focal="55" aperture="1.8" distance="10" k1="-1.8584" k2="1.7422" k3="-0.6920"/>
+            <vignetting model="pa" focal="55" aperture="1.8" distance="1000" k1="-1.8584" k2="1.7422" k3="-0.6920"/>
+            <vignetting model="pa" focal="55" aperture="2" distance="10" k1="-1.2143" k2="0.3692" k3="0.0795"/>
+            <vignetting model="pa" focal="55" aperture="2" distance="1000" k1="-1.2143" k2="0.3692" k3="0.0795"/>
+            <vignetting model="pa" focal="55" aperture="2.2" distance="10" k1="-0.6831" k2="-0.5506" k3="0.5258"/>
+            <vignetting model="pa" focal="55" aperture="2.2" distance="1000" k1="-0.6831" k2="-0.5506" k3="0.5258"/>
+            <vignetting model="pa" focal="55" aperture="2.5" distance="10" k1="-0.4113" k2="-0.8526" k3="0.6106"/>
+            <vignetting model="pa" focal="55" aperture="2.5" distance="1000" k1="-0.4113" k2="-0.8526" k3="0.6106"/>
+            <vignetting model="pa" focal="55" aperture="2.8" distance="10" k1="-0.2661" k2="-1.0262" k3="0.6722"/>
+            <vignetting model="pa" focal="55" aperture="2.8" distance="1000" k1="-0.2661" k2="-1.0262" k3="0.6722"/>
+            <vignetting model="pa" focal="55" aperture="3.2" distance="10" k1="-0.2010" k2="-0.8620" k3="0.4680"/>
+            <vignetting model="pa" focal="55" aperture="3.2" distance="1000" k1="-0.2010" k2="-0.8620" k3="0.4680"/>
+            <vignetting model="pa" focal="55" aperture="3.5" distance="10" k1="-0.2438" k2="-0.5705" k3="0.2327"/>
+            <vignetting model="pa" focal="55" aperture="3.5" distance="1000" k1="-0.2438" k2="-0.5705" k3="0.2327"/>
+            <vignetting model="pa" focal="55" aperture="4" distance="10" k1="-0.3348" k2="-0.1370" k3="-0.0929"/>
+            <vignetting model="pa" focal="55" aperture="4" distance="1000" k1="-0.3348" k2="-0.1370" k3="-0.0929"/>
+            <vignetting model="pa" focal="55" aperture="4.5" distance="10" k1="-0.4232" k2="0.2365" k3="-0.3562"/>
+            <vignetting model="pa" focal="55" aperture="4.5" distance="1000" k1="-0.4232" k2="0.2365" k3="-0.3562"/>
+            <vignetting model="pa" focal="55" aperture="5" distance="10" k1="-0.5008" k2="0.5218" k3="-0.5416"/>
+            <vignetting model="pa" focal="55" aperture="5" distance="1000" k1="-0.5008" k2="0.5218" k3="-0.5416"/>
+            <vignetting model="pa" focal="55" aperture="5.6" distance="10" k1="-0.5578" k2="0.7188" k3="-0.6501"/>
+            <vignetting model="pa" focal="55" aperture="5.6" distance="1000" k1="-0.5578" k2="0.7188" k3="-0.6501"/>
+            <vignetting model="pa" focal="55" aperture="8" distance="10" k1="-0.6475" k2="0.9412" k3="-0.6980"/>
+            <vignetting model="pa" focal="55" aperture="8" distance="1000" k1="-0.6475" k2="0.9412" k3="-0.6980"/>
+            <vignetting model="pa" focal="55" aperture="11" distance="10" k1="-0.6621" k2="0.7965" k3="-0.4469"/>
+            <vignetting model="pa" focal="55" aperture="11" distance="1000" k1="-0.6621" k2="0.7965" k3="-0.4469"/>
+            <vignetting model="pa" focal="55" aperture="16" distance="10" k1="-0.6680" k2="0.6426" k3="-0.2307"/>
+            <vignetting model="pa" focal="55" aperture="16" distance="1000" k1="-0.6680" k2="0.6426" k3="-0.2307"/>
+            <vignetting model="pa" focal="55" aperture="22" distance="10" k1="-0.6921" k2="0.6663" k3="-0.2238"/>
+            <vignetting model="pa" focal="55" aperture="22" distance="1000" k1="-0.6921" k2="0.6663" k3="-0.2238"/>
+         </calibration>
     </lens>
 
     <lens>
@@ -999,30 +1036,34 @@
             <distortion model="poly3" focal="28" k1="-0.02561"/>
             <tca model="poly3" focal="28" vr="1.0001366" vb="0.9999474"/>
             <!-- Taken with Sony A7 II with a different specimen of the lens -->
-            <vignetting model="pa" focal="28" aperture="2" distance="10" k1="-1.1730" k2="0.9438" k3="-0.3772"/>
-            <vignetting model="pa" focal="28" aperture="2" distance="1000" k1="-1.1730" k2="0.9438" k3="-0.3772"/>
-            <vignetting model="pa" focal="28" aperture="2.2" distance="10" k1="-0.5540" k2="-0.2830" k3="0.3149"/>
-            <vignetting model="pa" focal="28" aperture="2.2" distance="1000" k1="-0.5540" k2="-0.2830" k3="0.3149"/>
-            <vignetting model="pa" focal="28" aperture="2.5" distance="10" k1="-0.4649" k2="-0.1847" k3="0.2143"/>
-            <vignetting model="pa" focal="28" aperture="2.5" distance="1000" k1="-0.4649" k2="-0.1847" k3="0.2143"/>
-            <vignetting model="pa" focal="28" aperture="2.8" distance="10" k1="-0.8410" k2="0.6125" k3="-0.2240"/>
-            <vignetting model="pa" focal="28" aperture="2.8" distance="1000" k1="-0.8410" k2="0.6125" k3="-0.2240"/>
-            <vignetting model="pa" focal="28" aperture="3.2" distance="10" k1="-0.8418" k2="0.6007" k3="-0.2087"/>
-            <vignetting model="pa" focal="28" aperture="3.2" distance="1000" k1="-0.8418" k2="0.6007" k3="-0.2087"/>
-            <vignetting model="pa" focal="28" aperture="3.5" distance="10" k1="-0.7840" k2="0.3924" k3="-0.0806"/>
-            <vignetting model="pa" focal="28" aperture="3.5" distance="1000" k1="-0.7840" k2="0.3924" k3="-0.0806"/>
-            <vignetting model="pa" focal="28" aperture="4" distance="10" k1="-0.7644" k2="0.3339" k3="-0.0587"/>
-            <vignetting model="pa" focal="28" aperture="4" distance="1000" k1="-0.7644" k2="0.3339" k3="-0.0587"/>
-            <vignetting model="pa" focal="28" aperture="5.6" distance="10" k1="-0.7644" k2="0.3451" k3="-0.0712"/>
-            <vignetting model="pa" focal="28" aperture="5.6" distance="1000" k1="-0.7644" k2="0.3451" k3="-0.0712"/>
-            <vignetting model="pa" focal="28" aperture="8" distance="10" k1="-0.7696" k2="0.3486" k3="-0.0708"/>
-            <vignetting model="pa" focal="28" aperture="8" distance="1000" k1="-0.7696" k2="0.3486" k3="-0.0708"/>
-            <vignetting model="pa" focal="28" aperture="11" distance="10" k1="-0.7772" k2="0.3657" k3="-0.0813"/>
-            <vignetting model="pa" focal="28" aperture="11" distance="1000" k1="-0.7772" k2="0.3657" k3="-0.0813"/>
-            <vignetting model="pa" focal="28" aperture="16" distance="10" k1="-0.8056" k2="0.4193" k3="-0.1161"/>
-            <vignetting model="pa" focal="28" aperture="16" distance="1000" k1="-0.8056" k2="0.4193" k3="-0.1161"/>
-            <vignetting model="pa" focal="28" aperture="22" distance="10" k1="-0.8035" k2="0.4087" k3="-0.1092"/>
-            <vignetting model="pa" focal="28" aperture="22" distance="1000" k1="-0.8035" k2="0.4087" k3="-0.1092"/>
+            <vignetting model="pa" focal="28" aperture="2" distance="10" k1="-2.0849" k2="2.1046" k3="-0.8592"/>
+            <vignetting model="pa" focal="28" aperture="2" distance="1000" k1="-2.0849" k2="2.1046" k3="-0.8592"/>
+            <vignetting model="pa" focal="28" aperture="2.2" distance="10" k1="-1.3699" k2="0.5399" k3="0.0339"/>
+            <vignetting model="pa" focal="28" aperture="2.2" distance="1000" k1="-1.3699" k2="0.5399" k3="0.0339"/>
+            <vignetting model="pa" focal="28" aperture="2.5" distance="10" k1="-0.8192" k2="-0.4757" k3="0.5460"/>
+            <vignetting model="pa" focal="28" aperture="2.5" distance="1000" k1="-0.8192" k2="-0.4757" k3="0.5460"/>
+            <vignetting model="pa" focal="28" aperture="2.8" distance="10" k1="-0.6117" k2="-0.5937" k3="0.4958"/>
+            <vignetting model="pa" focal="28" aperture="2.8" distance="1000" k1="-0.6117" k2="-0.5937" k3="0.4958"/>
+            <vignetting model="pa" focal="28" aperture="3.2" distance="10" k1="-0.6594" k2="-0.1402" k3="0.1286"/>
+            <vignetting model="pa" focal="28" aperture="3.2" distance="1000" k1="-0.6594" k2="-0.1402" k3="0.1286"/>
+            <vignetting model="pa" focal="28" aperture="3.5" distance="10" k1="-0.7830" k2="0.3253" k3="-0.1709"/>
+            <vignetting model="pa" focal="28" aperture="3.5" distance="1000" k1="-0.7830" k2="0.3253" k3="-0.1709"/>
+            <vignetting model="pa" focal="28" aperture="4" distance="10" k1="-0.8184" k2="0.4389" k3="-0.2140"/>
+            <vignetting model="pa" focal="28" aperture="4" distance="1000" k1="-0.8184" k2="0.4389" k3="-0.2140"/>
+            <vignetting model="pa" focal="28" aperture="4.5" distance="10" k1="-0.8187" k2="0.4243" k3="-0.1752"/>
+            <vignetting model="pa" focal="28" aperture="4.5" distance="1000" k1="-0.8187" k2="0.4243" k3="-0.1752"/>
+            <vignetting model="pa" focal="28" aperture="5" distance="10" k1="-0.8081" k2="0.3749" k3="-0.1219"/>
+            <vignetting model="pa" focal="28" aperture="5" distance="1000" k1="-0.8081" k2="0.3749" k3="-0.1219"/>
+            <vignetting model="pa" focal="28" aperture="5.6" distance="10" k1="-0.7809" k2="0.2711" k3="-0.0280"/>
+            <vignetting model="pa" focal="28" aperture="5.6" distance="1000" k1="-0.7809" k2="0.2711" k3="-0.0280"/>
+            <vignetting model="pa" focal="28" aperture="8" distance="10" k1="-0.7782" k2="0.2591" k3="-0.0166"/>
+            <vignetting model="pa" focal="28" aperture="8" distance="1000" k1="-0.7782" k2="0.2591" k3="-0.0166"/>
+            <vignetting model="pa" focal="28" aperture="11" distance="10" k1="-0.7826" k2="0.2676" k3="-0.0232"/>
+            <vignetting model="pa" focal="28" aperture="11" distance="1000" k1="-0.7826" k2="0.2676" k3="-0.0232"/>
+            <vignetting model="pa" focal="28" aperture="16" distance="10" k1="-0.7926" k2="0.2536" k3="-0.0047"/>
+            <vignetting model="pa" focal="28" aperture="16" distance="1000" k1="-0.7926" k2="0.2536" k3="-0.0047"/>
+            <vignetting model="pa" focal="28" aperture="22" distance="10" k1="-0.7973" k2="0.2636" k3="-0.0126"/>
+            <vignetting model="pa" focal="28" aperture="22" distance="1000" k1="-0.7973" k2="0.2636" k3="-0.0126"/>
         </calibration>
     </lens>
 
@@ -1279,6 +1320,47 @@
             <vignetting model="pa" focal="35" aperture="11" distance="1000" k1="-0.5610" k2="0.0833" k3="0.0404"/>
             <vignetting model="pa" focal="35" aperture="22" distance="10" k1="-0.3400" k2="-0.9602" k3="0.9100"/>
             <vignetting model="pa" focal="35" aperture="22" distance="1000" k1="-0.3400" k2="-0.9602" k3="0.9100"/>
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Sony</maker>
+        <model>FE 85mm F1.8</model>
+        <mount>Sony E</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="85" a="-.011" b=".029" c="-.022"/>
+            <tca model="poly3" focal="85" vr="0.9999630" vb="0.9998815"/>
+            <vignetting model="pa" focal="85" aperture="1.8" distance="10" k1="-1.7181" k2="1.8217" k3="-0.8351"/>
+            <vignetting model="pa" focal="85" aperture="1.8" distance="1000" k1="-1.7181" k2="1.8217" k3="-0.8351"/>
+            <vignetting model="pa" focal="85" aperture="2" distance="10" k1="-1.1269" k2="0.5624" k3="-0.1229"/>
+            <vignetting model="pa" focal="85" aperture="2" distance="1000" k1="-1.1269" k2="0.5624" k3="-0.1229"/>
+            <vignetting model="pa" focal="85" aperture="2.2" distance="10" k1="-0.5659" k2="-0.3329" k3="0.2921"/>
+            <vignetting model="pa" focal="85" aperture="2.2" distance="1000" k1="-0.5659" k2="-0.3329" k3="0.2921"/>
+            <vignetting model="pa" focal="85" aperture="2.5" distance="10" k1="-0.3342" k2="-0.6075" k3="0.4057"/>
+            <vignetting model="pa" focal="85" aperture="2.5" distance="1000" k1="-0.3342" k2="-0.6075" k3="0.4057"/>
+            <vignetting model="pa" focal="85" aperture="2.8" distance="10" k1="-0.1091" k2="-0.9560" k3="0.5774"/>
+            <vignetting model="pa" focal="85" aperture="2.8" distance="1000" k1="-0.1091" k2="-0.9560" k3="0.5774"/>
+            <vignetting model="pa" focal="85" aperture="3.2" distance="10" k1="-0.0429" k2="-0.8675" k3="0.4351"/>
+            <vignetting model="pa" focal="85" aperture="3.2" distance="1000" k1="-0.0429" k2="-0.8675" k3="0.4351"/>
+            <vignetting model="pa" focal="85" aperture="3.5" distance="10" k1="-0.0726" k2="-0.5622" k3="0.1743"/>
+            <vignetting model="pa" focal="85" aperture="3.5" distance="1000" k1="-0.0726" k2="-0.5622" k3="0.1743"/>
+            <vignetting model="pa" focal="85" aperture="4" distance="10" k1="-0.1441" k2="-0.2247" k3="-0.0805"/>
+            <vignetting model="pa" focal="85" aperture="4" distance="1000" k1="-0.1441" k2="-0.2247" k3="-0.0805"/>
+            <vignetting model="pa" focal="85" aperture="4.5" distance="10" k1="-0.2235" k2="0.1034" k3="-0.3102"/>
+            <vignetting model="pa" focal="85" aperture="4.5" distance="1000" k1="-0.2235" k2="0.1034" k3="-0.3102"/>
+            <vignetting model="pa" focal="85" aperture="5" distance="10" k1="-0.2938" k2="0.3592" k3="-0.4753"/>
+            <vignetting model="pa" focal="85" aperture="5" distance="1000" k1="-0.2938" k2="0.3592" k3="-0.4753"/>
+            <vignetting model="pa" focal="85" aperture="5.6" distance="10" k1="-0.3384" k2="0.5022" k3="-0.5425"/>
+            <vignetting model="pa" focal="85" aperture="5.6" distance="1000" k1="-0.3384" k2="0.5022" k3="-0.5425"/>
+            <vignetting model="pa" focal="85" aperture="8" distance="10" k1="-0.3399" k2="0.4420" k3="-0.3841"/>
+            <vignetting model="pa" focal="85" aperture="8" distance="1000" k1="-0.3399" k2="0.4420" k3="-0.3841"/>
+            <vignetting model="pa" focal="85" aperture="11" distance="10" k1="-0.2099" k2="-0.0365" k3="0.0424"/>
+            <vignetting model="pa" focal="85" aperture="11" distance="1000" k1="-0.2099" k2="-0.0365" k3="0.0424"/>
+            <vignetting model="pa" focal="85" aperture="16" distance="10" k1="-0.2118" k2="-0.0298" k3="0.0416"/>
+            <vignetting model="pa" focal="85" aperture="16" distance="1000" k1="-0.2118" k2="-0.0298" k3="0.0416"/>
+            <vignetting model="pa" focal="85" aperture="22" distance="10" k1="-0.2161" k2="-0.0093" k3="0.0234"/>
+            <vignetting model="pa" focal="85" aperture="22" distance="1000" k1="-0.2161" k2="-0.0093" k3="0.0234"/>
         </calibration>
     </lens>
 


### PR DESCRIPTION
- Replace FE 2/28 vignetting data by real raw data (not pre-correction
  baked into the ARW) measured through a matte screen.
- Replace FE 3.5-5.6/28-70 OSS vignetting data, it was mixed from
  various incomplete sets and at least one had pre-correction baked into
  the ARW set.
- Replace FE 1.8/55 ZA T* vignetting data after re-measuring it with a
  proper matte screen.
- Add complete data (distortion, tca, vignetting) for Sony FE 1.8/85.