### PR TITLE
Added the Olympus E-M1 Mark II camera

### DIFF
--- a/data/db/mil-olympus.xml
+++ b/data/db/mil-olympus.xml
@@ -125,6 +125,14 @@
     <camera>
         <maker>Olympus Imaging Corp.</maker>
         <maker lang="en">Olympus</maker>
+        <model>E-M1MarkII</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Olympus Imaging Corp.</maker>
+        <maker lang="en">Olympus</maker>
         <model>E-M5</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>


### PR DESCRIPTION
This simple addition is sufficient to make darktable (and probably other tools too) lens-correct raw images taken with the relatively new E-M1 Mark II. Support for this camera was added in the latest version of darktable but lens correction doesn't work out of the box yet due to this missing entry.