### PR TITLE
Correct some Pentax crop factors

### DIFF
--- a/data/db/slr-pentax.xml
+++ b/data/db/slr-pentax.xml
@@ -339,7 +339,7 @@
         <model>Pentax K-01</model>
         <model lang="en">K-01</model>
         <mount>Pentax KAF2</mount>
-        <cropfactor>1.509</cropfactor>
+        <cropfactor>1.522</cropfactor>
     </camera>
 
     <camera>
@@ -347,7 +347,7 @@
         <model>Pentax KP</model>
         <model lang="en">KP</model>
         <mount>Pentax KAF2</mount>
-        <cropfactor>1.523</cropfactor>
+        <cropfactor>1.534</cropfactor>
     </camera>
 
     <lens>
@@ -1617,7 +1617,7 @@
         <maker>Pentax</maker>
         <model>HD Pentax-DA 18-50mm f/4-5.6 DC WR RE</model>
         <mount>Pentax KAF3</mount>
-        <cropfactor>1.509</cropfactor>
+        <cropfactor>1.522</cropfactor>
         <calibration>
             <!-- Taken with Pentax K-01 -->
             <distortion model="ptlens" focal="18" a="0.009" b="-0.038" c="0.012"/>


### PR DESCRIPTION
The crop factors for the Pentax K-01 and KP appear to have been slightly wrong. As reported by Julien Moreau, and confirmed from specs on the internet.