### PR TITLE
PENTAX K-3 II make is "RICOH IMAGING COMPANY, LTD."

### DIFF
--- a/data/db/slr-pentax.xml
+++ b/data/db/slr-pentax.xml
@@ -262,7 +262,7 @@
     </camera>
 
     <camera>
-        <maker>Pentax</maker>
+        <maker>Ricoh Imaging Company, Ltd.</maker>
         <model>Pentax K-3 II</model>
         <model lang="en">K-3 II</model>
         <mount>Pentax KAF2</mount>


### PR DESCRIPTION
and NOT Pentax

exiftool fragment for DNG file:

Make                            : RICOH IMAGING COMPANY, LTD.
Camera Model Name               : PENTAX K-3 II