### PR TITLE
Added Vignette correction for Nikon DX lenses

### DIFF
--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -3190,6 +3190,57 @@
             <distortion model="ptlens" focal="95" a="0.002" b="0.003" c="0.016"/>
             <distortion model="ptlens" focal="112" a="0.002" b="0.005" c="0.007"/>
             <distortion model="ptlens" focal="140" a="0.004" b="0.002" c="-0.002"/>
+            <!-- Taken with Nikon D5500 -->
+            <vignetting model="pa" focal="18" aperture="3.5" distance="10" k1="-1.0342" k2="1.2744" k3="-0.8591"/>
+            <vignetting model="pa" focal="18" aperture="3.5" distance="1000" k1="-1.0342" k2="1.2744" k3="-0.8591"/>
+            <vignetting model="pa" focal="18" aperture="5.6" distance="10" k1="-0.3512" k2="0.0587" k3="-0.1284"/>
+            <vignetting model="pa" focal="18" aperture="5.6" distance="1000" k1="-0.3512" k2="0.0587" k3="-0.1284"/>
+            <vignetting model="pa" focal="18" aperture="8" distance="10" k1="-0.3763" k2="0.1409" k3="-0.0154"/>
+            <vignetting model="pa" focal="18" aperture="8" distance="1000" k1="-0.3763" k2="0.1409" k3="-0.0154"/>
+            <vignetting model="pa" focal="18" aperture="11" distance="10" k1="-0.3611" k2="0.1238" k3="0.0049"/>
+            <vignetting model="pa" focal="18" aperture="11" distance="1000" k1="-0.3611" k2="0.1238" k3="0.0049"/>
+            <vignetting model="pa" focal="18" aperture="22" distance="10" k1="-0.3625" k2="0.1415" k3="-0.0107"/>
+            <vignetting model="pa" focal="18" aperture="22" distance="1000" k1="-0.3625" k2="0.1415" k3="-0.0107"/>
+            <vignetting model="pa" focal="35" aperture="4.2" distance="10" k1="-0.9972" k2="1.1837" k3="-0.6181"/>
+            <vignetting model="pa" focal="35" aperture="4.2" distance="1000" k1="-0.9972" k2="1.1837" k3="-0.6181"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="10" k1="-0.4259" k2="-0.0779" k3="0.1593"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="1000" k1="-0.4259" k2="-0.0779" k3="0.1593"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="10" k1="-0.2718" k2="0.2106" k3="-0.1398"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="1000" k1="-0.2718" k2="0.2106" k3="-0.1398"/>
+            <vignetting model="pa" focal="35" aperture="11" distance="10" k1="-0.2705" k2="0.1542" k3="-0.0346"/>
+            <vignetting model="pa" focal="35" aperture="11" distance="1000" k1="-0.2705" k2="0.1542" k3="-0.0346"/>
+            <vignetting model="pa" focal="35" aperture="29" distance="10" k1="-0.2734" k2="0.1822" k3="-0.0601"/>
+            <vignetting model="pa" focal="35" aperture="29" distance="1000" k1="-0.2734" k2="0.1822" k3="-0.0601"/>
+            <vignetting model="pa" focal="50" aperture="4.8" distance="10" k1="-0.9757" k2="1.2513" k3="-0.7280"/>
+            <vignetting model="pa" focal="50" aperture="4.8" distance="1000" k1="-0.9757" k2="1.2513" k3="-0.7280"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="10" k1="-0.7437" k2="0.6759" k3="-0.3425"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="1000" k1="-0.7437" k2="0.6759" k3="-0.3425"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="10" k1="-0.1072" k2="-0.2584" k3="0.1183"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="1000" k1="-0.1072" k2="-0.2584" k3="0.1183"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="10" k1="-0.2316" k2="0.1645" k3="-0.0769"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="1000" k1="-0.2316" k2="0.1645" k3="-0.0769"/>
+            <vignetting model="pa" focal="50" aperture="32" distance="10" k1="-0.2393" k2="0.1772" k3="-0.0770"/>
+            <vignetting model="pa" focal="50" aperture="32" distance="1000" k1="-0.2393" k2="0.1772" k3="-0.0770"/>
+            <vignetting model="pa" focal="70" aperture="5" distance="10" k1="-0.9356" k2="1.2982" k3="-0.9015"/>
+            <vignetting model="pa" focal="70" aperture="5" distance="1000" k1="-0.9356" k2="1.2982" k3="-0.9015"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="10" k1="-0.8845" k2="1.1860" k3="-0.8278"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="-0.8845" k2="1.1860" k3="-0.8278"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="10" k1="-0.1437" k2="-0.2255" k3="0.0476"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.1437" k2="-0.2255" k3="0.0476"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="10" k1="-0.2190" k2="0.2206" k3="-0.1506"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="1000" k1="-0.2190" k2="0.2206" k3="-0.1506"/>
+            <vignetting model="pa" focal="70" aperture="32" distance="10" k1="-0.2185" k2="0.1702" k3="-0.0789"/>
+            <vignetting model="pa" focal="70" aperture="32" distance="1000" k1="-0.2185" k2="0.1702" k3="-0.0789"/>
+            <vignetting model="pa" focal="140" aperture="5.6" distance="10" k1="-0.5003" k2="-0.0988" k3="-0.0134"/>
+            <vignetting model="pa" focal="140" aperture="5.6" distance="1000" k1="-0.5003" k2="-0.0988" k3="-0.0134"/>
+            <vignetting model="pa" focal="140" aperture="8" distance="10" k1="-0.0989" k2="-0.4015" k3="0.0414"/>
+            <vignetting model="pa" focal="140" aperture="8" distance="1000" k1="-0.0989" k2="-0.4015" k3="0.0414"/>
+            <vignetting model="pa" focal="140" aperture="11" distance="10" k1="-0.2031" k2="0.3357" k3="-0.2880"/>
+            <vignetting model="pa" focal="140" aperture="11" distance="1000" k1="-0.2031" k2="0.3357" k3="-0.2880"/>
+            <vignetting model="pa" focal="140" aperture="16" distance="10" k1="-0.1464" k2="0.0663" k3="-0.0206"/>
+            <vignetting model="pa" focal="140" aperture="16" distance="1000" k1="-0.1464" k2="0.0663" k3="-0.0206"/>
+            <vignetting model="pa" focal="140" aperture="36" distance="10" k1="-0.1613" k2="0.1003" k3="-0.0429"/>
+            <vignetting model="pa" focal="140" aperture="36" distance="1000" k1="-0.1613" k2="0.1003" k3="-0.0429"/>
         </calibration>
     </lens>
 
@@ -3824,6 +3875,57 @@
             <tca model="poly3" focal="135" vr="0.9999275" vb="0.9999038"/>
             <tca model="poly3" focal="200" vr="0.9998593" vb="0.9997647"/>
             <tca model="poly3" focal="300" vr="0.9997757" vb="0.9997447"/>
+            <!-- Taken with Nikon D5500 --> 
+            <vignetting model="pa" focal="70" aperture="4.5" distance="10" k1="-0.3477" k2="-0.2658" k3="0.1837"/>
+            <vignetting model="pa" focal="70" aperture="4.5" distance="1000" k1="-0.3477" k2="-0.2658" k3="0.1837"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="10" k1="0.0536" k2="-0.6052" k3="0.2352"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="0.0536" k2="-0.6052" k3="0.2352"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="10" k1="-0.1263" k2="0.1161" k3="-0.1022"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.1263" k2="0.1161" k3="-0.1022"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="10" k1="-0.1033" k2="0.0010" k3="0.0094"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="1000" k1="-0.1033" k2="0.0010" k3="0.0094"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="10" k1="-0.1015" k2="0.0111" k3="-0.0035"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="1000" k1="-0.1015" k2="0.0111" k3="-0.0035"/>
+            <vignetting model="pa" focal="100" aperture="4.8" distance="10" k1="-0.3774" k2="-0.1816" k3="0.1145"/>
+            <vignetting model="pa" focal="100" aperture="4.8" distance="1000" k1="-0.3774" k2="-0.1816" k3="0.1145"/>
+            <vignetting model="pa" focal="100" aperture="5.6" distance="10" k1="-0.0677" k2="-0.6304" k3="0.3142"/>
+            <vignetting model="pa" focal="100" aperture="5.6" distance="1000" k1="-0.0677" k2="-0.6304" k3="0.3142"/>
+            <vignetting model="pa" focal="100" aperture="8" distance="10" k1="-0.1485" k2="0.2587" k3="-0.2219"/>
+            <vignetting model="pa" focal="100" aperture="8" distance="1000" k1="-0.1485" k2="0.2587" k3="-0.2219"/>
+            <vignetting model="pa" focal="100" aperture="11" distance="10" k1="-0.1043" k2="0.0514" k3="-0.0180"/>
+            <vignetting model="pa" focal="100" aperture="11" distance="1000" k1="-0.1043" k2="0.0514" k3="-0.0180"/>
+            <vignetting model="pa" focal="100" aperture="25" distance="10" k1="-0.1109" k2="0.0779" k3="-0.0436"/>
+            <vignetting model="pa" focal="100" aperture="25" distance="1000" k1="-0.1109" k2="0.0779" k3="-0.0436"/>
+            <vignetting model="pa" focal="135" aperture="4.8" distance="10" k1="-0.1985" k2="-0.7890" k3="0.4259"/>
+            <vignetting model="pa" focal="135" aperture="4.8" distance="1000" k1="-0.1985" k2="-0.7890" k3="0.4259"/>
+            <vignetting model="pa" focal="135" aperture="5.6" distance="10" k1="0.1877" k2="-1.4217" k3="0.7224"/>
+            <vignetting model="pa" focal="135" aperture="5.6" distance="1000" k1="0.1877" k2="-1.4217" k3="0.7224"/>
+            <vignetting model="pa" focal="135" aperture="8" distance="10" k1="-0.0540" k2="0.1642" k3="-0.4022"/>
+            <vignetting model="pa" focal="135" aperture="8" distance="1000" k1="-0.0540" k2="0.1642" k3="-0.4022"/>
+            <vignetting model="pa" focal="135" aperture="11" distance="10" k1="-0.1565" k2="0.3242" k3="-0.2729"/>
+            <vignetting model="pa" focal="135" aperture="11" distance="1000" k1="-0.1565" k2="0.3242" k3="-0.2729"/>
+            <vignetting model="pa" focal="135" aperture="25" distance="10" k1="-0.1075" k2="0.0973" k3="-0.0513"/>
+            <vignetting model="pa" focal="135" aperture="25" distance="1000" k1="-0.1075" k2="0.0973" k3="-0.0513"/>
+            <vignetting model="pa" focal="200" aperture="5.3" distance="10" k1="-0.3494" k2="-0.7578" k3="0.5624"/>
+            <vignetting model="pa" focal="200" aperture="5.3" distance="1000" k1="-0.3494" k2="-0.7578" k3="0.5624"/>
+            <vignetting model="pa" focal="200" aperture="5.6" distance="10" k1="-0.2770" k2="-0.8938" k3="0.6346"/>
+            <vignetting model="pa" focal="200" aperture="5.6" distance="1000" k1="-0.2770" k2="-0.8938" k3="0.6346"/>
+            <vignetting model="pa" focal="200" aperture="8" distance="10" k1="0.1650" k2="-0.7376" k3="0.2618"/>
+            <vignetting model="pa" focal="200" aperture="8" distance="1000" k1="0.1650" k2="-0.7376" k3="0.2618"/>
+            <vignetting model="pa" focal="200" aperture="11" distance="10" k1="-0.0922" k2="0.2574" k3="-0.2982"/>
+            <vignetting model="pa" focal="200" aperture="11" distance="1000" k1="-0.0922" k2="0.2574" k3="-0.2982"/>
+            <vignetting model="pa" focal="200" aperture="29" distance="10" k1="-0.0781" k2="0.0535" k3="-0.0301"/>
+            <vignetting model="pa" focal="200" aperture="29" distance="1000" k1="-0.0781" k2="0.0535" k3="-0.0301"/>
+            <vignetting model="pa" focal="300" aperture="6.3" distance="10" k1="-0.9008" k2="0.5995" k3="-0.2133"/>
+            <vignetting model="pa" focal="300" aperture="6.3" distance="1000" k1="-0.9008" k2="0.5995" k3="-0.2133"/>
+            <vignetting model="pa" focal="300" aperture="8" distance="10" k1="-0.1151" k2="-0.5324" k3="0.3076"/>
+            <vignetting model="pa" focal="300" aperture="8" distance="1000" k1="-0.1151" k2="-0.5324" k3="0.3076"/>
+            <vignetting model="pa" focal="300" aperture="11" distance="10" k1="-0.0473" k2="0.1266" k3="-0.1743"/>
+            <vignetting model="pa" focal="300" aperture="11" distance="1000" k1="-0.0473" k2="0.1266" k3="-0.1743"/>
+            <vignetting model="pa" focal="300" aperture="16" distance="10" k1="-0.0407" k2="0.0101" k3="-0.0070"/>
+            <vignetting model="pa" focal="300" aperture="16" distance="1000" k1="-0.0407" k2="0.0101" k3="-0.0070"/>
+            <vignetting model="pa" focal="300" aperture="32" distance="10" k1="-0.0584" k2="0.0417" k3="-0.0317"/>
+            <vignetting model="pa" focal="300" aperture="32" distance="1000" k1="-0.0584" k2="0.0417" k3="-0.0317"/>
         </calibration>
     </lens>
 


### PR DESCRIPTION
Added Vignette correction to the following nikon DX lenses:
Nikon AF-S DX Nikkor 18-140mm f/3.5-5.6G ED VR
Nikon AF-P DX Nikkor 70-300mm f/4.5-6.3G ED VR

Tested with the images used for calibration and on field footage and compared to previously edited ones in lightroom.

The cropfactor of my camera is slightly different for the one that already exists for the 18-140mm lens (1.534 instead of 1.523). But to make it work locally on the local database (~/local/share/lensfun/ path) on darktable, I had to put it under the 1.523 crop one. Not sure if it is intended just FYI :)