### PR TITLE
Add distortion data for Sony RX100M6

### DIFF
--- a/data/db/compact-sony.xml
+++ b/data/db/compact-sony.xml
@@ -216,6 +216,14 @@
         <mount>sonyRX100III</mount>
         <cropfactor>2.73</cropfactor>
     </camera>
+    
+    <camera>
+        <maker>Sony</maker>
+        <model>DSC-RX100M6</model>
+        <model lang="en">RX100 VI</model>
+        <mount>sonyRX100VI</model>
+        <cropfactor>2.73</cropfactor>
+    </camera>
 
     <camera>
         <maker>Sony</maker>
@@ -1156,6 +1164,28 @@
             <tca model="poly3" focal="16.6" br="0.0000075" vr="1.0002936" bb="-0.0000085" vb="1.0000657"/>
             <tca model="poly3" focal="20" br="-0.0000081" vr="1.0003041" bb="0.0000035" vb="1.0000616"/>
             <tca model="poly3" focal="25.7" br="-0.0000121" vr="1.0002604" bb="0.0000035" vb="1.0000797"/>
+        </calibration>
+    </lens>
+    
+    <lens>
+        <maker>Sony</maker>
+        <model>Standard</model>
+        <mount>sonyRX100VI</mount>
+        <cropfactor>2.73</cropfactor>
+        <aspect-ratio>3:2</aspect-ratio>
+        <calibration>
+            <distortion model="ptlens" focal="9" a="0.05" b="-0.177" c="0.049"/>
+            <distortion model="ptlens" focal="12" a="0.019" b="-0.07" c="0.007"/>
+            <distortion model="ptlens" focal="14.4" a="-0.012" b="0.049" c="-0.096"/>
+            <distortion model="ptlens" focal="20.3" a="0.021" b="-0.046" c="0.026"/>
+            <distortion model="ptlens" focal="21.1" a="0.008" b="-0.02" c="0.029"/>
+            <distortion model="ptlens" focal="29.7" a="-0.003" b="0.039" c="-0.045"/>
+            <distortion model="ptlens" focal="30.9" a="0.018" b="-0.03" c="0.027"/>
+            <distortion model="ptlens" focal="32.1" a="-0.021" b="0.095" c="-0.098"/>
+            <distortion model="ptlens" focal="41.9" a="-0.024" b="0.079" c="-0.05"/>
+            <distortion model="ptlens" focal="45.2" a="0.035" b="-0.097" c="0.125"/>
+            <distortion model="ptlens" focal="71" a="-0.034" b="0.142" c="-0.132"/>
+            <distortion model="ptlens" focal="72" a="-0.004" b="0.034" c="-0.01"/>
         </calibration>
     </lens>
 

--- a/data/db/compact-sony.xml
+++ b/data/db/compact-sony.xml
@@ -1174,18 +1174,18 @@
         <cropfactor>2.73</cropfactor>
         <aspect-ratio>3:2</aspect-ratio>
         <calibration>
-            <distortion model="ptlens" focal="9" a="0.05" b="-0.177" c="0.049"/>
-            <distortion model="ptlens" focal="12" a="0.019" b="-0.07" c="0.007"/>
-            <distortion model="ptlens" focal="14.4" a="-0.012" b="0.049" c="-0.096"/>
-            <distortion model="ptlens" focal="20.3" a="0.021" b="-0.046" c="0.026"/>
-            <distortion model="ptlens" focal="21.1" a="0.008" b="-0.02" c="0.029"/>
-            <distortion model="ptlens" focal="29.7" a="-0.003" b="0.039" c="-0.045"/>
-            <distortion model="ptlens" focal="30.9" a="0.018" b="-0.03" c="0.027"/>
-            <distortion model="ptlens" focal="32.1" a="-0.021" b="0.095" c="-0.098"/>
-            <distortion model="ptlens" focal="41.9" a="-0.024" b="0.079" c="-0.05"/>
-            <distortion model="ptlens" focal="45.2" a="0.035" b="-0.097" c="0.125"/>
-            <distortion model="ptlens" focal="71" a="-0.034" b="0.142" c="-0.132"/>
-            <distortion model="ptlens" focal="72" a="-0.004" b="0.034" c="-0.01"/>
+            <distortion model="ptlens" focal="9" a="0.05026" b="-0.18188" c="0.06157"/>
+            <distortion model="ptlens" focal="12" a="0.02057" b="-0.08142" c="0.0258"/>
+            <distortion model="ptlens" focal="14.4" a="0.02993" b="-0.1072" c="0.0869"/>
+            <distortion model="ptlens" focal="20.3" a="0.00242" b="0.00929" c="-0.02655"/>
+            <distortion model="ptlens" focal="21.1" a="0.00909" b="-0.02392" c="0.02906"/>
+            <distortion model="ptlens" focal="29.7" a="0.00893" b="-0.0062" c="0.00811"/>
+            <distortion model="ptlens" focal="30.9" a="0.02926" b="-0.07814" c="0.08534"/>
+            <distortion model="ptlens" focal="32.1" a="0.01837" b="-0.04109" c="0.05074"/>
+            <distortion model="ptlens" focal="41.9" a="0.03069" b="-0.07852" c="0.08789"/>
+            <distortion model="ptlens" focal="45.2" a="0.0147" b="-0.02611" c="0.03583"/>
+            <distortion model="ptlens" focal="71" a="0.00356" b="0.01397" c="0.00231"/>
+            <distortion model="ptlens" focal="72" a="0.01906" b="-0.03384" c="0.04513"/>
         </calibration>
     </lens>
 

--- a/data/db/compact-sony.xml
+++ b/data/db/compact-sony.xml
@@ -1174,18 +1174,17 @@
         <cropfactor>2.73</cropfactor>
         <aspect-ratio>3:2</aspect-ratio>
         <calibration>
-            <distortion model="ptlens" focal="9" a="0.05026" b="-0.18188" c="0.06157"/>
-            <distortion model="ptlens" focal="12" a="0.02057" b="-0.08142" c="0.0258"/>
-            <distortion model="ptlens" focal="14.4" a="0.02993" b="-0.1072" c="0.0869"/>
-            <distortion model="ptlens" focal="20.3" a="0.00242" b="0.00929" c="-0.02655"/>
-            <distortion model="ptlens" focal="21.1" a="0.00909" b="-0.02392" c="0.02906"/>
-            <distortion model="ptlens" focal="29.7" a="0.00893" b="-0.0062" c="0.00811"/>
-            <distortion model="ptlens" focal="30.9" a="0.02926" b="-0.07814" c="0.08534"/>
-            <distortion model="ptlens" focal="32.1" a="0.01837" b="-0.04109" c="0.05074"/>
-            <distortion model="ptlens" focal="41.9" a="0.03069" b="-0.07852" c="0.08789"/>
-            <distortion model="ptlens" focal="45.2" a="0.0147" b="-0.02611" c="0.03583"/>
-            <distortion model="ptlens" focal="71" a="0.00356" b="0.01397" c="0.00231"/>
-            <distortion model="ptlens" focal="72" a="0.01906" b="-0.03384" c="0.04513"/>
+            <distortion model="ptlens" focal="9" a="0.05599" b="-0.20458" c="0.09024"/>
+            <distortion model="ptlens" focal="11.5" a="0.02059" b="-0.08149" c="0.01416"/>
+            <distortion model="ptlens" focal="14.7" a="0.01298" b="-0.04455" c="0.01025"/>
+            <distortion model="ptlens" focal="18.6" a="0.00712" b="-0.01128" c="-0.00813"/>
+            <distortion model="ptlens" focal="23.9" a="0.00935" b="-0.01464" c="0.00921"/>
+            <distortion model="ptlens" focal="25.3" a="0.00722" b="-0.00809" c="0.00767"/>
+            <distortion model="ptlens" focal="27.4" a="0.01912" b="-0.04776" c="0.05191"/>
+            <distortion model="ptlens" focal="31.5" a="0.019" b="-0.05053" c="0.06565"/>
+            <distortion model="ptlens" focal="36.7" a="0.00274" b="0.01879" c="-0.02364"/>
+            <distortion model="ptlens" focal="47.9" a="-0.00349" b="0.03918" c="-0.03616"/>
+            <distortion model="ptlens" focal="72" a="0.0035" b="0.01401" c="-0.00579"/>
         </calibration>
     </lens>
 


### PR DESCRIPTION
I tried to use the process through the website but received a failure email with a link to a page that 404'ed, so I decided to do it myself.

I first did it by hand using the process described in the documentation but the values appeared chaotic and thought they looked okay, I forgot to copy the entire value from Hugin rather than just the 3 digits shown on the optimization screen. The result of this process is in the first commit.

At that point I discovered Hugin has a much more automated lens calibration GUI so I used that. The results were more consistent and looked fine aside from 45mm. So I did 45mm by hand and it looked better so I went with that. The result of this process is in the second commit.