### PR TITLE
[LENS] Add Sony SEL1635GM and SEL85F18GM

### DIFF
--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -1381,6 +1381,105 @@
 
     <lens>
         <maker>Sony</maker>
+        <model>FE 16-35mm f/2.8 GM</model>
+        <mount>Sony E</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+           <distortion model="ptlens" focal="16" a="0.021" b="-0.052" c="-0.003" />
+           <distortion model="ptlens" focal="17" a="0.016" b="-0.033" c="-0.014" />
+           <distortion model="ptlens" focal="18" a="0.02" b="-0.05" c="0.009" />
+           <distortion model="ptlens" focal="19" a="0.023" b="-0.058" c="0.024" />
+           <distortion model="ptlens" focal="20" a="0.016" b="-0.036" c="0.004" />
+           <distortion model="ptlens" focal="21" a="0.027" b="-0.08" c="0.065" />
+           <distortion model="ptlens" focal="22" a="0.02" b="-0.057" c="0.046" />
+           <distortion model="ptlens" focal="23" a="0.018" b="-0.049" c="0.043" />
+           <distortion model="ptlens" focal="24" a="0.015" b="-0.036" c="0.027" />
+           <distortion model="ptlens" focal="25" a="0.019" b="-0.05" c="0.045" />
+           <distortion model="ptlens" focal="26" a="0.017" b="-0.0440" c="0.038" />
+           <distortion model="ptlens" focal="27" a="0.011" b="-0.027" c="0.029" />
+           <distortion model="ptlens" focal="28" a="0.01" b="-0.021" c="0.019" />
+           <distortion model="ptlens" focal="29" a="0.008" b="-0.012" c="0.008" />
+           <distortion model="ptlens" focal="30" a="0.013" b="-0.027" c="0.023" />
+           <distortion model="ptlens" focal="31" a="0.001" b="0.005" c="0.002" />
+           <distortion model="ptlens" focal="32" a="0.006" b="-0.013" c="0.026" />
+           <distortion model="ptlens" focal="33" a="0.003" b="0.0" c="0.01" />
+           <distortion model="ptlens" focal="34" a="-0.003" b="0.024" c="0.023" />
+           <distortion model="ptlens" focal="35" a="0.002" b="0.01" c="-0.009" />
+           <tca model="poly3" focal="16.0" vr="1.0003371" vb="1.0002001" />
+           <tca model="poly3" focal="17.0" vr="1.0002961" vb="1.0002093" />
+           <tca model="poly3" focal="18.0" vr="1.0002771" vb="1.0002079" />
+           <tca model="poly3" focal="19.0" vr="1.0002887" vb="1.0001817" />
+           <tca model="poly3" focal="20.0" vr="1.0003024" vb="1.0001604" />
+           <tca model="poly3" focal="21.0" vr="1.0003281" vb="1.0001377" />
+           <tca model="poly3" focal="22.0" vr="1.0003129" vb="1.0001247" />
+           <tca model="poly3" focal="23.0" vr="1.0003294" vb="1.0000922" />
+           <tca model="poly3" focal="24.0" vr="1.0003362" vb="1.0000724" />
+           <tca model="poly3" focal="25.0" vr="1.0003246" vb="1.0000542" />
+           <tca model="poly3" focal="26.0" vr="1.0003365" vb="1.0000335" />
+           <tca model="poly3" focal="27.0" vr="1.0003312" vb="1.0000247" />
+           <tca model="poly3" focal="28.0" vr="1.0002862" vb="1.0000130" />
+           <tca model="poly3" focal="29.0" vr="1.0002884" vb="1.0000093" />
+           <tca model="poly3" focal="30.0" vr="1.0002753" vb="1.0000091" />
+           <tca model="poly3" focal="31.0" vr="1.0002525" vb="1.0000082" />
+           <tca model="poly3" focal="32.0" vr="1.0002121" vb="1.0000130" />
+           <tca model="poly3" focal="33.0" vr="1.0001960" vb="1.0000056" />
+           <tca model="poly3" focal="34.0" vr="1.0001655" vb="1.0000020" />
+           <tca model="poly3" focal="35.0" vr="1.0001354" vb="1.0000187" />
+           <vignetting model="pa" focal="16.0" aperture="2.8" distance="10" k1="-1.1426838" k2="-0.1327780" k3="0.4286505" />
+           <vignetting model="pa" focal="16.0" aperture="2.8" distance="1000" k1="-1.1426838" k2="-0.1327780" k3="0.4286505" />
+           <vignetting model="pa" focal="16.0" aperture="4.0" distance="10" k1="-1.2197836" k2="0.5690637" k3="-0.1383930" />
+           <vignetting model="pa" focal="16.0" aperture="4.0" distance="1000" k1="-1.2197836" k2="0.5690637" k3="-0.1383930" />
+           <vignetting model="pa" focal="16.0" aperture="5.6" distance="10" k1="-1.3399568" k2="1.0815054" k3="-0.4792415" />
+           <vignetting model="pa" focal="16.0" aperture="5.6" distance="1000" k1="-1.3399568" k2="1.0815054" k3="-0.4792415" />
+           <vignetting model="pa" focal="16.0" aperture="8.0" distance="10" k1="-1.3588003" k2="1.1289689" k3="-0.4634028" />
+           <vignetting model="pa" focal="16.0" aperture="8.0" distance="1000" k1="-1.3588003" k2="1.1289689" k3="-0.4634028" />
+           <vignetting model="pa" focal="16.0" aperture="22.0" distance="10" k1="-1.3226984" k2="1.0058316" k3="-0.3570543" />
+           <vignetting model="pa" focal="16.0" aperture="22.0" distance="1000" k1="-1.3226984" k2="1.0058316" k3="-0.3570543" />
+           <vignetting model="pa" focal="20.0" aperture="2.8" distance="10" k1="-0.9620096" k2="-0.1406903" k3="0.3313801" />
+           <vignetting model="pa" focal="20.0" aperture="2.8" distance="1000" k1="-0.9620096" k2="-0.1406903" k3="0.3313801" />
+           <vignetting model="pa" focal="20.0" aperture="4.0" distance="10" k1="-1.0644418" k2="0.6378988" k3="-0.2535907" />
+           <vignetting model="pa" focal="20.0" aperture="4.0" distance="1000" k1="-1.0644418" k2="0.6378988" k3="-0.2535907" />
+           <vignetting model="pa" focal="20.0" aperture="5.6" distance="10" k1="-1.1012139" k2="0.8057817" k3="-0.3247674" />
+           <vignetting model="pa" focal="20.0" aperture="5.6" distance="1000" k1="-1.1012139" k2="0.8057817" k3="-0.3247674" />
+           <vignetting model="pa" focal="20.0" aperture="8.0" distance="10" k1="-1.0762599" k2="0.7700741" k3="-0.3080835" />
+           <vignetting model="pa" focal="20.0" aperture="8.0" distance="1000" k1="-1.0762599" k2="0.7700741" k3="-0.3080835" />
+           <vignetting model="pa" focal="20.0" aperture="22.0" distance="10" k1="-0.9926709" k2="0.6066566" k3="-0.2216714" />
+           <vignetting model="pa" focal="20.0" aperture="22.0" distance="1000" k1="-0.9926709" k2="0.6066566" k3="-0.2216714" />
+           <vignetting model="pa" focal="24.0" aperture="2.8" distance="10" k1="-0.7244937" k2="-0.2783907" k3="0.3141927" />
+           <vignetting model="pa" focal="24.0" aperture="2.8" distance="1000" k1="-0.7244937" k2="-0.2783907" k3="0.3141927" />
+           <vignetting model="pa" focal="24.0" aperture="4.0" distance="10" k1="-0.9434067" k2="0.6731092" k3="-0.3078864" />
+           <vignetting model="pa" focal="24.0" aperture="4.0" distance="1000" k1="-0.9434067" k2="0.6731092" k3="-0.3078864" />
+           <vignetting model="pa" focal="24.0" aperture="5.6" distance="10" k1="-0.9503389" k2="0.6310115" k3="-0.2485693" />
+           <vignetting model="pa" focal="24.0" aperture="5.6" distance="1000" k1="-0.9503389" k2="0.6310115" k3="-0.2485693" />
+           <vignetting model="pa" focal="24.0" aperture="8.0" distance="10" k1="-0.9622364" k2="0.6275710" k3="-0.2343902" />
+           <vignetting model="pa" focal="24.0" aperture="8.0" distance="1000" k1="-0.9622364" k2="0.6275710" k3="-0.2343902" />
+           <vignetting model="pa" focal="24.0" aperture="22.0" distance="10" k1="-1.0117586" k2="0.7020757" k3="-0.2655781" />
+           <vignetting model="pa" focal="24.0" aperture="22.0" distance="1000" k1="-1.0117586" k2="0.7020757" k3="-0.2655781" />
+           <vignetting model="pa" focal="28.0" aperture="2.8" distance="10" k1="-0.8011475" k2="-0.0294712" k3="0.1792173" />
+           <vignetting model="pa" focal="28.0" aperture="2.8" distance="1000" k1="-0.8011475" k2="-0.0294712" k3="0.1792173" />
+           <vignetting model="pa" focal="28.0" aperture="4.0" distance="10" k1="-0.3000000" k2="0.0000000" k3="-0.0000000" />
+           <vignetting model="pa" focal="28.0" aperture="4.0" distance="1000" k1="-0.3000000" k2="0.0000000" k3="-0.0000000" />
+           <vignetting model="pa" focal="28.0" aperture="5.6" distance="10" k1="-0.8213533" k2="0.4817157" k3="-0.1981381" />
+           <vignetting model="pa" focal="28.0" aperture="5.6" distance="1000" k1="-0.8213533" k2="0.4817157" k3="-0.1981381" />
+           <vignetting model="pa" focal="28.0" aperture="8.0" distance="10" k1="-0.8050180" k2="0.4601850" k3="-0.1909765" />
+           <vignetting model="pa" focal="28.0" aperture="8.0" distance="1000" k1="-0.8050180" k2="0.4601850" k3="-0.1909765" />
+           <vignetting model="pa" focal="28.0" aperture="22.0" distance="10" k1="-0.8158299" k2="0.4968270" k3="-0.2186255" />
+           <vignetting model="pa" focal="28.0" aperture="22.0" distance="1000" k1="-0.8158299" k2="0.4968270" k3="-0.2186255" />
+           <vignetting model="pa" focal="35.0" aperture="2.8" distance="10" k1="-0.8869089" k2="0.3271503" k3="-0.0544243" />
+           <vignetting model="pa" focal="35.0" aperture="2.8" distance="1000" k1="-0.8869089" k2="0.3271503" k3="-0.0544243" />
+           <vignetting model="pa" focal="35.0" aperture="4.0" distance="10" k1="-0.6921073" k2="0.4407751" k3="-0.2343183" />
+           <vignetting model="pa" focal="35.0" aperture="4.0" distance="1000" k1="-0.6921073" k2="0.4407751" k3="-0.2343183" />
+           <vignetting model="pa" focal="35.0" aperture="5.6" distance="10" k1="-0.6485520" k2="0.3457927" k3="-0.1744346" />
+           <vignetting model="pa" focal="35.0" aperture="5.6" distance="1000" k1="-0.6485520" k2="0.3457927" k3="-0.1744346" />
+           <vignetting model="pa" focal="35.0" aperture="8.0" distance="10" k1="-0.6362926" k2="0.3264912" k3="-0.1622949" />
+           <vignetting model="pa" focal="35.0" aperture="8.0" distance="1000" k1="-0.6362926" k2="0.3264912" k3="-0.1622949" />
+           <vignetting model="pa" focal="35.0" aperture="22.0" distance="10" k1="-0.6627731" k2="0.3813111" k3="-0.1907616" />
+           <vignetting model="pa" focal="35.0" aperture="22.0" distance="1000" k1="-0.6627731" k2="0.3813111" k3="-0.1907616" />
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Sony</maker>
         <model>FE 16-35mm f/4 ZA OSS</model>
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>

--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -1588,6 +1588,27 @@
 
     <lens>
         <maker>Sony</maker>
+        <model>FE 85mm f/1.4 GM</model>
+        <mount>Sony E</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+           <distortion model="ptlens" focal="85" a="0.002" b="0.001" c="-0.009" />
+           <tca model="poly3" focal="85.0" vr="1.0001739" vb="0.9998863" />
+           <vignetting model="pa" focal="85.0" aperture="1.4" distance="10" k1="0.0255248" k2="1.2726464" k3="1.1334426" />
+           <vignetting model="pa" focal="85.0" aperture="1.4" distance="1000" k1="0.0255248" k2="1.2726464" k3="1.1334426" />
+           <vignetting model="pa" focal="85.0" aperture="2.0" distance="10" k1="0.0727763" k2="-1.5312690" k3="0.8846760" />
+           <vignetting model="pa" focal="85.0" aperture="2.0" distance="1000" k1="0.0727763" k2="-1.5312690" k3="0.8846760" />
+           <vignetting model="pa" focal="85.0" aperture="2.8" distance="10" k1="-0.0376922" k2="-0.3484006" k3="-0.1197605" />
+           <vignetting model="pa" focal="85.0" aperture="2.8" distance="1000" k1="-0.0376922" k2="-0.3484006" k3="-0.1197605" />
+           <vignetting model="pa" focal="85.0" aperture="4.0" distance="10" k1="-0.2875749" k2="0.6343450" k3="-0.7626592" />
+           <vignetting model="pa" focal="85.0" aperture="4.0" distance="1000" k1="-0.2875749" k2="0.6343450" k3="-0.7626592" />
+           <vignetting model="pa" focal="85.0" aperture="16.0" distance="10" k1="-0.1971090" k2="0.0217729" k3="0.0098701" />
+           <vignetting model="pa" focal="85.0" aperture="16.0" distance="1000" k1="-0.1971090" k2="0.0217729" k3="0.0098701" />
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Sony</maker>
         <model>FE 85mm f/1.8</model>
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>


### PR DESCRIPTION
Hi,

this adds too new Sony lenses to lensfun.

You can find all the data here:

https://xor.cryptomilk.org/lensfun/SEL1635GM_calibration.tar.xz
https://xor.cryptomilk.org/lensfun/SEL85F18GM_calibration.tar.xz

Those files include the plots for TCA and vignetting. The package includes plots and preview files for vignetting corrections.

https://gitlab.com/cryptomilk/lens_calibrate