### PR TITLE
Add Panasonic DC-LX100M2 camera+lens

### DIFF
--- a/data/db/compact-panasonic.xml
+++ b/data/db/compact-panasonic.xml
@@ -291,6 +291,14 @@
 
     <camera>
         <maker>Panasonic</maker>
+        <model>DC-LX100M2</model>
+        <!-- Same lens as LX100 -->
+        <mount>panasonicDMCLX100</mount>
+        <cropfactor>2.21</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Panasonic</maker>
         <model>DMC-FZ1000</model>
         <mount>panasonicFZ1000</mount>
         <cropfactor>2.73</cropfactor>


### PR DESCRIPTION
This links the configuration for the LX100 mark 2 to the existing configuration for the LX100, since the LX100 Mark 2 uses the same lens as the older LX100.
Note that Panasonic changed the prefix from DMC to just DC.

