### PR TITLE
Add camera: Panasonic DC-GX800

### DIFF
--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -214,6 +214,14 @@
         <cropfactor>2</cropfactor>
     </camera>
 
+    <camera>
+        <!-- The GX800 is also known as GX850 and GF9 in some regions. -->
+        <maker>Panasonic</maker>
+        <model>DC-GX800</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G 14mm f/2.5 Asph.</model>


### PR DESCRIPTION
Example Exif info from a picture:
```
$ exiv2 -pt P1000400.RW2 | grep Model
Exif.PanasonicRaw.Model                      Ascii       9  DC-GX800
Exif.Image.Model                             Ascii       9  DC-GX800
```
The camera comes with a kit lens which is already in lensfun database.