### PR TITLE
Travis: Update macOS image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 dist: xenial
-osx_image: xcode10.1
+osx_image: xcode11
 compiler:
   - clang
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
       compiler: gcc # gcc = clang in macOS, unecessary duplicate
   include:
     - name: docs
+      if: repo = lensfun/lensfun AND branch = master
       stage: docs
       os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ matrix:
         provider: pages
         local_dir: $TRAVIS_BUILD_DIR/lensfun_doc
         skip_cleanup: true
-        github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+        github_token: $GITHUB_TOKEN # Set in the settings page of your repository, as a secure variable
         keep_history: true
         repo: lensfun/lensfun.github.io
         target_branch: master

--- a/tests/test_modifier_coord_perspective_correction.cpp
+++ b/tests/test_modifier_coord_perspective_correction.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <limits>
 #include <cmath>
+#include <locale>
 
 #include "lensfun.h"
 #include "../libs/lensfun/lensfunprv.h"

--- a/tests/test_modifier_coord_perspective_correction_old.cpp
+++ b/tests/test_modifier_coord_perspective_correction_old.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <limits>
 #include <cmath>
+#include <locale>
 
 #include "lensfun.h"
 #include "../libs/lensfun/lensfunprv.h"

--- a/tests/test_modifier_coord_tiny_image_old.cpp
+++ b/tests/test_modifier_coord_tiny_image_old.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 #include <cmath>
 #include <vector>
+#include <locale>
 
 #include "lensfun.h"
 #include "../libs/lensfun/lensfunprv.h"

--- a/tests/test_modifier_performance.cpp
+++ b/tests/test_modifier_performance.cpp
@@ -2,6 +2,7 @@
 #include <limits>
 #include <map>
 #include <cmath>
+#include <locale>
 #include "xmmintrin.h"
 #include "time.h"
 

--- a/tests/test_modifier_regression.cpp
+++ b/tests/test_modifier_regression.cpp
@@ -2,6 +2,7 @@
 #include <limits>
 #include <map>
 #include <cmath>
+#include <locale>
 
 #include "lensfun.h"
 #include "../libs/lensfun/lensfunprv.h"


### PR DESCRIPTION
homebrew complains when not updated in a while, and since travis-ci does not seem to update their old images, either better upgrade the image or update hombrew (which takes a while)