### PR TITLE
Catch unhandled exception in lensfun-update-data

### DIFF
--- a/apps/lensfun-update-data
+++ b/apps/lensfun-update-data
@@ -116,8 +116,8 @@ def read_location(base_url):
         print("Reading {} …".format(base_url + "versions.json"))
         try:
             response = urllib.request.urlopen(base_url + "versions.json")
-        except (urllib.error.HTTPError, ValueError):
-            print("  Error: URL could not be opened.")
+        except (urllib.error.HTTPError, urllib.error.URLError, ValueError) as e:
+            print("  Error: URL could not be opened, skipping: " + str(e))
         else:
             try:
                 timestamp, versions, alternatives = json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
lensfun-update-data is crashing on OSX due to an unhandled exception.  Fix

Also improve the error message to include the actual error