### PR TITLE
Fix lf_db_load_data

### DIFF
--- a/include/lensfun/lensfun.h.in
+++ b/include/lensfun/lensfun.h.in
@@ -1823,6 +1823,25 @@ struct LF_EXPORT lfDatabase
     lfError Load (const char *data, size_t data_size);
 
     /**
+     * @brief Load a set of camera/lenses from a memory array.
+     *
+     * This function is deprecated and will be removed in the future.
+     * Please use the lfDatabase::Load(const char *data, size_t data_size) syntax instead.
+     * 
+     * This is the lowest-level loading function.
+     * @param errcontext
+     *     The error context to be displayed in error messages
+     *     (usually this is the name of the file to which data belongs).
+     * @param data
+     *     The XML data.
+     * @param data_size
+     *     XML data size in bytes.
+     * @return
+     *     LF_NO_ERROR or a error code.
+     */
+    DEPRECATED lfError Load (const char *errcontext, const char *data, size_t data_size);
+
+    /**
      * @brief Save the whole database to a file.
      * @param filename
      *     The file name to write the XML stream into.
@@ -2033,8 +2052,6 @@ private:
      */
     int MatchScore (const lfLens *pattern, const lfLens *match, const lfCamera *camera,
                                 void *fuzzycmp, const char* const* compat_mounts) const;
-
-    lfError Load (const char *errcontext, const char *data, size_t data_size);
 
     std::vector<lfMount*>  Mounts;
     std::vector<lfCamera*> Cameras;

--- a/libs/lensfun/database.cpp
+++ b/libs/lensfun/database.cpp
@@ -1580,9 +1580,9 @@ lfError lf_db_load_path (lfDatabase *db, const char *pathname)
     return db->Load (pathname);
 }
 
-lfError lf_db_load_data (lfDatabase *db, const char *data, size_t data_size)
+lfError lf_db_load_data (lfDatabase *db, const char *errcontext, const char *data, size_t data_size)
 {
-    return db->Load (data, data_size);
+    return db->Load (errcontext, data, data_size);
 }
 
 lfError lf_db_save_all (const lfDatabase *db, const char *filename)


### PR DESCRIPTION
`lf_db_load_data` had the wrong signature in the implementation not matching the header. This PR fixes that. Also, `Load (const char *errcontext, const char *data, size_t data_size)` is made public again (so that it can be called from `lf_db_load_data`) but marked as `DEPRECATED`. Note the docstring was copied from the last release (minus the sentence about deprecation).

This fixes an issue from #502. Re-designing the load functions is not part of this PR, but simply to get lensfun into a working state again.