### PR TITLE
Easy typo fixes

### DIFF
--- a/docs/man/lensfun-add-adapter.1.rst
+++ b/docs/man/lensfun-add-adapter.1.rst
@@ -45,12 +45,12 @@ select the mount of the lenses you can now put on your camera, using the
 adapter.  That's it.
 
 With the options ``--maker``, ``--model``, and ``--mount``, you can avoid
-interactive mode by passing the nevcessary data explicitly.  If you pass only
+interactive mode by passing the necessary data explicitly.  If you pass only
 maker/model or only mount, ``lensfun-add-adapter`` will enter interactive mode
 only for the missing data.
 
 You can also use ``lensfun-add-adapter`` to reset your adapter configuration.
-Call it with the ``--help`` paremeter to see all functions.
+Call it with the ``--help`` parameter to see all functions.
 
 OPTIONS
 =========

--- a/docs/manual-main.txt
+++ b/docs/manual-main.txt
@@ -222,7 +222,7 @@ select the mount of the lenses you can now put on your camera, using the
 adapter.  That's it.
 
 You can also use lensfun‑add‑adapter to reset your adapter configuration.  Call
-it with the ‑‑help paremeter to see all functions.
+it with the ‑‑help parameter to see all functions.
 
 @page lensfun-convert-lcp Converting Adobe LCP files to Lensfun: lensfun‑convert‑lcp
 

--- a/libs/lensfun/database.cpp
+++ b/libs/lensfun/database.cpp
@@ -232,7 +232,7 @@ static void _xml_start_element (GMarkupParseContext *context,
         {
         bad_ctx:
             g_set_error (error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
-                         "Inappropiate context for <%s>!\n", element_name);
+                         "Inappropriate context for <%s>!\n", element_name);
             return;
         }
 


### PR DESCRIPTION
- inappropiate -> inappropriate
- nevcessary -> necessary
- paremeter -> parameter