### PR TITLE
Added Canon EOS KISS M camera

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -70,6 +70,14 @@
 
     <camera>
         <maker>Canon</maker>
+        <model>Canon EOS KISS M</model>
+        <model lang="en">EOS KISS M</model>
+        <mount>Canon EF-M</mount>
+        <cropfactor>1.613</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
         <model>Canon EOS M100</model>
         <model lang="en">EOS M100</model>
         <mount>Canon EF-M</mount>


### PR DESCRIPTION
It's actually the same as the Canon EOS M50, just a version of it released for the Japanese market.

Added an entry to the camera database so darktable can automatically pick up the right lens
correction profile from the EXIF data.