### PR TITLE
Added Tamron 17-35 F/2.8-4 Di OSD

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -77,6 +77,79 @@
     </lens>
 
     <lens>
+        <maker>Tamron</maker>
+        <model>17-35mm F/2.8-4 Di OSD</model>
+        <!-- The 'LensIDNumber' EXIF tag - use with old versions of exiv2 -->
+        <model>203</model>
+        <mount>Canon EF</mount>
+        <mount>Nikon F AF</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <!-- Taken with Nikon D750 -->
+            <distortion model="ptlens" focal="17" a="0.017" b="-0.075" c="0.066" />
+            <distortion model="ptlens" focal="20" a="0.004" b="-0.018" c="0.017" />
+            <distortion model="ptlens" focal="24" a="-0.001" b="0.002" c="0.006" />
+            <distortion model="ptlens" focal="28" a="0.001" b="0.002" c="0.002" />
+            <distortion model="ptlens" focal="35" a="0.003" b="0.001" c="0.002" />
+            <tca model="poly3" focal="17.0" vr="1.0001006" vb="1.0000015" />
+            <tca model="poly3" focal="20.0" vr="1.0001011" vb="0.9999992" />
+            <tca model="poly3" focal="24.0" vr="1.0000230" vb="1.0000366" />
+            <tca model="poly3" focal="28.0" vr="1.0000070" vb="1.0000373" />
+            <tca model="poly3" focal="35.0" vr="1.0000145" vb="0.9999855" />
+            <vignetting model="pa" focal="17.0" aperture="2.8" distance="10" k1="-1.1777632" k2="0.6793531" k3="-0.2158552" />
+            <vignetting model="pa" focal="17.0" aperture="2.8" distance="1000" k1="-1.1777632" k2="0.6793531" k3="-0.2158552" />
+            <vignetting model="pa" focal="17.0" aperture="4.0" distance="10" k1="-0.3323399" k2="-0.0659866" k3="-0.1173478" />
+            <vignetting model="pa" focal="17.0" aperture="4.0" distance="1000" k1="-0.3323399" k2="-0.0659866" k3="-0.1173478" />
+            <vignetting model="pa" focal="17.0" aperture="5.6" distance="10" k1="-0.4366817" k2="0.2620849" k3="-0.2348809" />
+            <vignetting model="pa" focal="17.0" aperture="5.6" distance="1000" k1="-0.4366817" k2="0.2620849" k3="-0.2348809" />
+            <vignetting model="pa" focal="17.0" aperture="8.0" distance="10" k1="-0.3694098" k2="-0.0235406" k3="0.0307611" />
+            <vignetting model="pa" focal="17.0" aperture="8.0" distance="1000" k1="-0.3694098" k2="-0.0235406" k3="0.0307611" />
+            <vignetting model="pa" focal="17.0" aperture="16.0" distance="10" k1="-0.3955165" k2="-0.0258012" k3="0.0463757" />
+            <vignetting model="pa" focal="17.0" aperture="16.0" distance="1000" k1="-0.3955165" k2="-0.0258012" k3="0.0463757" />
+            <vignetting model="pa" focal="20.0" aperture="2.8" distance="10" k1="-1.0437343" k2="0.3864531" k3="0.0070932" />
+            <vignetting model="pa" focal="20.0" aperture="2.8" distance="1000" k1="-1.0437343" k2="0.3864531" k3="0.0070932" />
+            <vignetting model="pa" focal="20.0" aperture="4.0" distance="10" k1="-0.2030697" k2="-0.4608053" k3="0.2207526" />
+            <vignetting model="pa" focal="20.0" aperture="4.0" distance="1000" k1="-0.2030697" k2="-0.4608053" k3="0.2207526" />
+            <vignetting model="pa" focal="20.0" aperture="5.6" distance="10" k1="-0.3576670" k2="-0.0737017" k3="0.0751651" />
+            <vignetting model="pa" focal="20.0" aperture="5.6" distance="1000" k1="-0.3576670" k2="-0.0737017" k3="0.0751651" />
+            <vignetting model="pa" focal="20.0" aperture="8.0" distance="10" k1="-0.3751903" k2="-0.0737985" k3="0.0838165" />
+            <vignetting model="pa" focal="20.0" aperture="8.0" distance="1000" k1="-0.3751903" k2="-0.0737985" k3="0.0838165" />
+            <vignetting model="pa" focal="20.0" aperture="16.0" distance="10" k1="-0.4433732" k2="-0.0338978" k3="0.0858514" />
+            <vignetting model="pa" focal="20.0" aperture="16.0" distance="1000" k1="-0.4433732" k2="-0.0338978" k3="0.0858514" />
+            <vignetting model="pa" focal="24.0" aperture="3.2" distance="10" k1="-0.8327660" k2="0.1283443" k3="0.1120680" />
+            <vignetting model="pa" focal="24.0" aperture="3.2" distance="1000" k1="-0.8327660" k2="0.1283443" k3="0.1120680" />
+            <vignetting model="pa" focal="24.0" aperture="4.0" distance="10" k1="-0.1952070" k2="-0.6178491" k3="0.3620964" />
+            <vignetting model="pa" focal="24.0" aperture="4.0" distance="1000" k1="-0.1952070" k2="-0.6178491" k3="0.3620964" />
+            <vignetting model="pa" focal="24.0" aperture="5.6" distance="10" k1="-0.3391807" k2="-0.0780455" k3="0.0793038" />
+            <vignetting model="pa" focal="24.0" aperture="5.6" distance="1000" k1="-0.3391807" k2="-0.0780455" k3="0.0793038" />
+            <vignetting model="pa" focal="24.0" aperture="8.0" distance="10" k1="-0.3355131" k2="-0.0733234" k3="0.0744572" />
+            <vignetting model="pa" focal="24.0" aperture="8.0" distance="1000" k1="-0.3355131" k2="-0.0733234" k3="0.0744572" />
+            <vignetting model="pa" focal="24.0" aperture="18.0" distance="10" k1="-0.3675040" k2="-0.0579484" k3="0.0766877" />
+            <vignetting model="pa" focal="24.0" aperture="18.0" distance="1000" k1="-0.3675040" k2="-0.0579484" k3="0.0766877" />
+            <vignetting model="pa" focal="28.0" aperture="3.5" distance="10" k1="-0.6859470" k2="-0.0064940" k3="0.1532379" />
+            <vignetting model="pa" focal="28.0" aperture="3.5" distance="1000" k1="-0.6859470" k2="-0.0064940" k3="0.1532379" />
+            <vignetting model="pa" focal="28.0" aperture="4.8" distance="10" k1="-0.2166217" k2="-0.2643549" k3="0.1189468" />
+            <vignetting model="pa" focal="28.0" aperture="4.8" distance="1000" k1="-0.2166217" k2="-0.2643549" k3="0.1189468" />
+            <vignetting model="pa" focal="28.0" aperture="6.7" distance="10" k1="-0.2962626" k2="-0.0587932" k3="0.0548188" />
+            <vignetting model="pa" focal="28.0" aperture="6.7" distance="1000" k1="-0.2962626" k2="-0.0587932" k3="0.0548188" />
+            <vignetting model="pa" focal="28.0" aperture="9.5" distance="10" k1="-0.2987348" k2="-0.0533317" k3="0.0513472" />
+            <vignetting model="pa" focal="28.0" aperture="9.5" distance="1000" k1="-0.2987348" k2="-0.0533317" k3="0.0513472" />
+            <vignetting model="pa" focal="28.0" aperture="20.0" distance="10" k1="-0.3500719" k2="-0.0350208" k3="0.0585603" />
+            <vignetting model="pa" focal="28.0" aperture="20.0" distance="1000" k1="-0.3500719" k2="-0.0350208" k3="0.0585603" />
+            <vignetting model="pa" focal="35.0" aperture="4.0" distance="10" k1="-0.4909510" k2="-0.1306144" k3="0.1696569" />
+            <vignetting model="pa" focal="35.0" aperture="4.0" distance="1000" k1="-0.4909510" k2="-0.1306144" k3="0.1696569" />
+            <vignetting model="pa" focal="35.0" aperture="5.6" distance="10" k1="-0.2059472" k2="-0.1044243" k3="0.0348525" />
+            <vignetting model="pa" focal="35.0" aperture="5.6" distance="1000" k1="-0.2059472" k2="-0.1044243" k3="0.0348525" />
+            <vignetting model="pa" focal="35.0" aperture="8.0" distance="10" k1="-0.2623285" k2="-0.0471495" k3="0.0463904" />
+            <vignetting model="pa" focal="35.0" aperture="8.0" distance="1000" k1="-0.2623285" k2="-0.0471495" k3="0.0463904" />
+            <vignetting model="pa" focal="35.0" aperture="11.0" distance="10" k1="-0.2662086" k2="-0.0436343" k3="0.0453315" />
+            <vignetting model="pa" focal="35.0" aperture="11.0" distance="1000" k1="-0.2662086" k2="-0.0436343" k3="0.0453315" />
+            <vignetting model="pa" focal="35.0" aperture="22.0" distance="10" k1="-0.3218184" k2="-0.0140004" k3="0.0454482" />
+            <vignetting model="pa" focal="35.0" aperture="22.0" distance="1000" k1="-0.3218184" k2="-0.0140004" k3="0.0454482" />
+        </calibration>
+    </lens>
+
+    <lens>
         <!-- This is an alias of Tamron SP AF 17-50mm f/2.8 XR Di II LD
              Aspherical (IF).  According to da...@corr.eu.org, they are
              optically equivalent. -->


### PR DESCRIPTION
Contains `203` as model number which will be obsolete once [the exiv2 PR is merged](https://github.com/Exiv2/exiv2/pull/1105), similarly to another lens definition in the same file.

Closes #1104