### PR TITLE
Remove shebang from __init__.py.in

### DIFF
--- a/apps/lensfun/__init__.py.in
+++ b/apps/lensfun/__init__.py.in
@@ -1,7 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
-
 """The Lensfun Python package.  It provides common functionality for Python
 scripts that want to find or read the Lensfun database.
 


### PR DESCRIPTION
Usually, an `__init__` file doesn't need a shebang or, if it does, it should be marked as executable.