### PR TITLE
Increase tolerance for tests involving SVD.

### DIFF
--- a/tests/test_modifier_coord_perspective_correction.cpp
+++ b/tests/test_modifier_coord_perspective_correction.cpp
@@ -82,7 +82,7 @@ void test_mod_coord_pc_svd (lfFixture *lfFix, gconstpointer data)
         M [i][5] = 1;
     }
     dvector result = svd (M);
-    const float epsilon = std::numeric_limits<double>::epsilon();
+    const double epsilon = std::numeric_limits<double>::epsilon() * 5;
     g_assert_cmpfloat (fabs (result [0] - 0.04756514941544937), <=, epsilon);
     g_assert_cmpfloat (fabs (result [1] - 0.09513029883089875), <=, epsilon);
     g_assert_cmpfloat (fabs (result [2] - 0.1902605976617977), <=, epsilon);

--- a/tests/test_modifier_coord_perspective_correction_old.cpp
+++ b/tests/test_modifier_coord_perspective_correction_old.cpp
@@ -88,7 +88,7 @@ void test_mod_coord_pc_svd (lfFixture *lfFix, gconstpointer data)
         M [i][5] = 1;
     }
     dvector result = svd (M);
-    const float epsilon = std::numeric_limits<double>::epsilon();
+    const double epsilon = std::numeric_limits<double>::epsilon() * 5;
     g_assert_cmpfloat (fabs (result [0] - 0.04756514941544937), <=, epsilon);
     g_assert_cmpfloat (fabs (result [1] - 0.09513029883089875), <=, epsilon);
     g_assert_cmpfloat (fabs (result [2] - 0.1902605976617977), <=, epsilon);


### PR DESCRIPTION
The epsilon provided by std::numeric_limits<double> can lead to tests
failing when certain optimizations and/or instructions such as FMA are
used by the compiler. Increasing the epsilon by a factor of 5 allows
the tests to pass while still ensuring the SVD is correct.
This fixes #1135.