### PR TITLE
Added Sigma 35 1.2 and 105 1.4

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -237,5 +237,141 @@
             <distortion model="ptlens" focal="16" a="0.019888" b="-0.0654977" c="0.0396784"/>
         </calibration>
     </lens>
+    
+    <lens>
+        <maker>Sigma</maker>
+        <model>105mm F1.4 DG HSM | Art 018</model>
+        <mount>Sony E</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="105" a="0.0014406142874951258" b="-0.00614583454138938" c="0.0127487278055209"/>
+            <tca model="poly3" focal="105" vr="0.9999963" vb="1.0000321"/>
+            <vignetting model="pa" focal="105" aperture="1.4" distance="0.94" k1="-0.6216" k2="0.2295" k3="-0.0333"/>
+            <vignetting model="pa" focal="105" aperture="1.4" distance="1.24" k1="-0.7525" k2="0.3478" k3="-0.0853"/>
+            <vignetting model="pa" focal="105" aperture="1.4" distance="1.86" k1="-0.9692" k2="0.6186" k3="-0.2043"/>
+            <vignetting model="pa" focal="105" aperture="1.4" distance="3.32" k1="-1.2254" k2="1.0427" k3="-0.4294"/>
+            <vignetting model="pa" focal="105" aperture="1.4" distance="10.47" k1="-1.3994" k2="1.3324" k3="-0.5880"/>
+            <vignetting model="pa" focal="105" aperture="1.4" distance="1000" k1="-1.4603" k2="1.3914" k3="-0.6134"/>
+            <vignetting model="pa" focal="105" aperture="2" distance="0.94" k1="-0.1032" k2="-0.1026" k3="-0.0040"/>
+            <vignetting model="pa" focal="105" aperture="2" distance="1.24" k1="-0.1242" k2="-0.0799" k3="-0.0255"/>
+            <vignetting model="pa" focal="105" aperture="2" distance="1.86" k1="-0.1390" k2="-0.0582" k3="-0.0885"/>
+            <vignetting model="pa" focal="105" aperture="2" distance="3.32" k1="-0.0949" k2="-0.2848" k3="0.0315"/>
+            <vignetting model="pa" focal="105" aperture="2" distance="10.47" k1="-0.0734" k2="-0.5248" k3="0.1920"/>
+            <vignetting model="pa" focal="105" aperture="2" distance="1000" k1="-0.1010" k2="-0.6476" k3="0.2937"/>
+            <vignetting model="pa" focal="105" aperture="2.8" distance="0.94" k1="-0.1403" k2="-0.0137" k3="0.0203"/>
+            <vignetting model="pa" focal="105" aperture="2.8" distance="1.24" k1="-0.1526" k2="-0.0205" k3="0.0263"/>
+            <vignetting model="pa" focal="105" aperture="2.8" distance="1.86" k1="-0.1660" k2="-0.0276" k3="0.0317"/>
+            <vignetting model="pa" focal="105" aperture="2.8" distance="3.32" k1="-0.1794" k2="-0.0370" k3="0.0391"/>
+            <vignetting model="pa" focal="105" aperture="2.8" distance="10.47" k1="-0.2220" k2="0.0677" k3="-0.0582"/>
+            <vignetting model="pa" focal="105" aperture="2.8" distance="1000" k1="-0.2466" k2="0.1354" k3="-0.1548"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="0.94" k1="-0.1260" k2="-0.0460" k3="0.0430"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="1.24" k1="-0.1443" k2="-0.0355" k3="0.0354"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="1.86" k1="-0.1606" k2="-0.0361" k3="0.0379"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="3.32" k1="-0.1771" k2="-0.0374" k3="0.0403"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="10.47" k1="-0.1942" k2="-0.0346" k3="0.0387"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="1000" k1="-0.2091" k2="-0.0378" k3="0.0433"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="0.94" k1="-0.1078" k2="-0.0813" k3="0.0621"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="1.24" k1="-0.1260" k2="-0.0712" k3="0.0565"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="1.86" k1="-0.1461" k2="-0.0596" k3="0.0495"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="3.32" k1="-0.1641" k2="-0.0574" k3="0.0500"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="10.47" k1="-0.1827" k2="-0.0521" k3="0.0479"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="1000" k1="-0.1957" k2="-0.0546" k3="0.0494"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="0.94" k1="-0.0942" k2="-0.1076" k3="0.0776"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="1.24" k1="-0.1139" k2="-0.0899" k3="0.0656"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="1.86" k1="-0.1319" k2="-0.0766" k3="0.0553"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="3.32" k1="-0.1481" k2="-0.0865" k3="0.0666"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="10.47" k1="-0.1640" k2="-0.0894" k3="0.0705"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="1000" k1="-0.1822" k2="-0.0811" k3="0.0657"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="0.94" k1="-0.0756" k2="-0.1476" k3="0.1028"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="1.24" k1="-0.0975" k2="-0.1165" k3="0.0769"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="1.86" k1="-0.1088" k2="-0.1287" k3="0.0870"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="3.32" k1="-0.1233" k2="-0.1373" k3="0.0969"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="10.47" k1="-0.1476" k2="-0.1114" k3="0.0795"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="1000" k1="-0.1649" k2="-0.1053" k3="0.0771"/>
+        </calibration>
+    </lens>
+    
+    <lens>
+        <maker>Sigma</maker>
+        <model>35mm F1.2 DG DN | Art 019</model>
+        <mount>Sony E</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="35" a="-0.00036252595632404257" b="-0.010365850618003318" c="0.00024978328908901364"/>
+            <tca model="poly3" focal="35" vr="1.0000559" vb="1.0000748"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="0.21" k1="-1.1670" k2="0.5109" k3="-0.0680"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="0.24" k1="-1.3674" k2="0.8452" k3="-0.2326"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="0.33" k1="-1.5691" k2="1.2082" k3="-0.4215"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="0.51" k1="-1.7405" k2="1.5250" k3="-0.5894"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="0.65" k1="-1.8030" k2="1.6391" k3="-0.6495"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="1.15" k1="-1.8742" k2="1.7627" k3="-0.7120"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="2" k1="-1.9086" k2="1.8253" k3="-0.7464"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="5.36" k1="-1.9334" k2="1.8661" k3="-0.7668"/>
+            <vignetting model="pa" focal="35" aperture="1.2" distance="1000" k1="-1.9857" k2="1.9445" k3="-0.8027"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="0.21" k1="-0.9376" k2="0.1167" k3="0.1193"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="0.24" k1="-0.8986" k2="-0.0878" k3="0.2684"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="0.33" k1="-1.0164" k2="0.0360" k3="0.2350"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="0.51" k1="-1.0669" k2="0.0547" k3="0.2486"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="0.65" k1="-1.2177" k2="0.3384" k3="0.1002"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="1.15" k1="-1.2258" k2="0.3174" k3="0.1212"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="2" k1="-1.2556" k2="0.3614" k3="0.1012"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="5.36" k1="-1.2569" k2="0.3487" k3="0.1119"/>
+            <vignetting model="pa" focal="35" aperture="1.4" distance="1000" k1="-1.3524" k2="0.5151" k3="0.0276"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="0.21" k1="-0.3247" k2="-0.1500" k3="-0.0226"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="0.24" k1="-0.3307" k2="-0.1726" k3="-0.0278"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="0.33" k1="-0.3101" k2="-0.3086" k3="0.0528"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="0.51" k1="-0.2921" k2="-0.4437" k3="0.1430"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="0.65" k1="-0.2819" k2="-0.5294" k3="0.2044"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="1.15" k1="-0.2835" k2="-0.5836" k3="0.2468"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="2" k1="-0.2758" k2="-0.6597" k3="0.3042"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="5.36" k1="-0.2814" k2="-0.6705" k3="0.3157"/>
+            <vignetting model="pa" focal="35" aperture="2" distance="1000" k1="-0.2973" k2="-0.7438" k3="0.3857"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="0.21" k1="-0.4098" k2="0.1106" k3="-0.0700"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="0.24" k1="-0.4322" k2="0.1255" k3="-0.0726"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="0.33" k1="-0.4559" k2="0.1408" k3="-0.0743"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="0.51" k1="-0.4943" k2="0.2230" k3="-0.1386"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="0.65" k1="-0.5130" k2="0.2674" k3="-0.1775"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="1.15" k1="-0.5306" k2="0.3036" k3="-0.2128"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="2" k1="-0.5393" k2="0.3210" k3="-0.2319"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="5.36" k1="-0.5435" k2="0.3225" k3="-0.2359"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="1000" k1="-0.5572" k2="0.3304" k3="-0.2585"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.21" k1="-0.3578" k2="-0.1036" k3="0.1276"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.24" k1="-0.3776" k2="-0.0951" k3="0.1294"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.33" k1="-0.4005" k2="-0.0800" k3="0.1269"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.51" k1="-0.4187" k2="-0.0698" k3="0.1252"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.65" k1="-0.4287" k2="-0.0602" k3="0.1213"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="1.15" k1="-0.4407" k2="-0.0513" k3="0.1185"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="2" k1="-0.4474" k2="-0.0467" k3="0.1175"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="5.36" k1="-0.4549" k2="-0.0368" k3="0.1121"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="1000" k1="-0.4794" k2="-0.0084" k3="0.0990"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.21" k1="-0.3539" k2="-0.1101" k3="0.1285"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.24" k1="-0.3734" k2="-0.1033" k3="0.1327"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.33" k1="-0.3975" k2="-0.0851" k3="0.1283"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.51" k1="-0.4179" k2="-0.0714" k3="0.1261"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.65" k1="-0.4283" k2="-0.0604" k3="0.1211"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="1.15" k1="-0.4422" k2="-0.0471" k3="0.1160"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="2" k1="-0.4502" k2="-0.0389" k3="0.1125"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="5.36" k1="-0.4572" k2="-0.0316" k3="0.1096"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="1000" k1="-0.4819" k2="-0.0038" k3="0.0980"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.21" k1="-0.3513" k2="-0.1155" k3="0.1294"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.24" k1="-0.3701" k2="-0.1106" k3="0.1353"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.33" k1="-0.3963" k2="-0.0845" k3="0.1250"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.51" k1="-0.4165" k2="-0.0724" k3="0.1251"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.65" k1="-0.4268" k2="-0.0623" k3="0.1213"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="1.15" k1="-0.4384" k2="-0.0562" k3="0.1218"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="2" k1="-0.4470" k2="-0.0464" k3="0.1174"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="5.36" k1="-0.4536" k2="-0.0398" k3="0.1147"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="1000" k1="-0.4796" k2="-0.0058" k3="0.0980"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.21" k1="-0.3597" k2="-0.1016" k3="0.1204"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.24" k1="-0.3745" k2="-0.1063" k3="0.1329"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.33" k1="-0.3928" k2="-0.1137" k3="0.1515"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.51" k1="-0.4195" k2="-0.0777" k3="0.1325"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.65" k1="-0.4316" k2="-0.0600" k3="0.1222"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="1.15" k1="-0.4457" k2="-0.0434" k3="0.1143"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="2" k1="-0.4518" k2="-0.0391" k3="0.1132"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="5.36" k1="-0.4588" k2="-0.0312" k3="0.1099"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="1000" k1="-0.4839" k2="0.0012" k3="0.0945"/>
+        </calibration>
+    </lens>
 
 </lensdatabase>


### PR DESCRIPTION
Added Sigma 105mm F1.4 DG HSM | Art 018 (Should also work for Canon EF and Nikon F versions) and
Sigma 35mm F1.2 DG DN | Art 019

Both have distortion, tca and vignetting (at various distances, as vignetting differs strongly with distance at least for the 35mm).