### PR TITLE
mil-sigma.xml

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -184,7 +184,7 @@
 
     <lens>
         <maker>Sigma</maker>
-        <model>SIGMA 30mm f/1.4 DC DN | C 016</model>
+        <model>Sigma 30mm f/1.4 DC DN | C 016</model>
         <model lang="en">30mm f/1.4 DC DN</model>
         <mount>Sony E</mount>
         <mount>Micro 4/3 System</mount>
@@ -212,7 +212,7 @@
 
     <lens>
         <maker>Sigma</maker>
-        <model>Sigma 16mm f/1.4 DC DN | Contemporary C 017</model>
+        <model>Sigma 16mm f/1.4 DC DN | C 017</model>
         <model lang="en">Sigma 16mm f/1.4 DC DN C</model>
         <mount>Micro 4/3 System</mount>
         <mount>Sony E</mount>


### PR DESCRIPTION
Fixed Lens names:

Sigma 16mm f/1.4 DC DN | Contemporary C 017 -> Sigma 16mm f/1.4 DC DN | C 017
"Contemporary" is redundant, since the "C" in the name stands for contemporary

SIGMA 30mm f/1.4 DC DN | C 016 -> Sigma 30mm f/1.4 DC DN | C 016
Fixed capitalization of "Sigma" to match other Sigma lenses