### PR TITLE
Scaling API backward compatibility to 0.3.2

### DIFF
--- a/include/lensfun/lensfun.h.in
+++ b/include/lensfun/lensfun.h.in
@@ -3048,6 +3048,9 @@ private:
 
     /// Indicates which modifications are enabled in this lfModifier
     int EnabledMods;
+    
+    /// Needed for scaling compatibility to 0.3.2
+    double scaling_d;
 };
 
 #ifdef __cplusplus

--- a/libs/lensfun/mod-coord.cpp
+++ b/libs/lensfun/mod-coord.cpp
@@ -34,7 +34,7 @@
 #include <limits>
 
 lfLensCalibDistortion rescale_polynomial_coefficients (const lfLensCalibDistortion& lcd_,
-                                                       double real_focal, cbool Reverse)
+                                                       double real_focal, cbool Reverse, double *scaling_d)
 {
     // FixMe: The ACM probably bases on the nominal focal length.  This needs
     // to be found out.  It this is true, we have to scale its coefficient by
@@ -43,11 +43,12 @@ lfLensCalibDistortion rescale_polynomial_coefficients (const lfLensCalibDistorti
     const float hugin_scale_in_millimeters =
         hypot (36.0, 24.0) / lcd.CalibAttr.CropFactor / hypot (lcd.CalibAttr.AspectRatio, 1) / 2.0;
     const float hugin_scaling = real_focal / hugin_scale_in_millimeters;
+    float d = 1;
     switch (lcd.Model)
     {
         case LF_DIST_MODEL_POLY3:
         {
-            const float d = 1 - lcd.Terms [0];
+            d = 1 - lcd.Terms [0];
             lcd.Terms [0] *= pow (hugin_scaling, 2) / pow (d, 3);
             break;
         }
@@ -57,7 +58,7 @@ lfLensCalibDistortion rescale_polynomial_coefficients (const lfLensCalibDistorti
             break;
         case LF_DIST_MODEL_PTLENS:
         {
-            const float d = 1 - lcd.Terms [0] - lcd.Terms [1] - lcd.Terms [2];
+            d = 1 - lcd.Terms [0] - lcd.Terms [1] - lcd.Terms [2];
             lcd.Terms [0] *= pow (hugin_scaling, 3) / pow (d, 4);
             lcd.Terms [1] *= pow (hugin_scaling, 2) / pow (d, 3);
             lcd.Terms [2] *= hugin_scaling / pow (d, 2);
@@ -67,12 +68,14 @@ lfLensCalibDistortion rescale_polynomial_coefficients (const lfLensCalibDistorti
             // keep gcc 4.4+ happy
             break;
     }
+    // This is needed for scaling compatibility to 0.3.2
+    *scaling_d = d;
     return lcd;
 }
 
 int lfModifier::EnableDistortionCorrection (const lfLensCalibDistortion& lcd_)
 {
-    const lfLensCalibDistortion lcd = rescale_polynomial_coefficients (lcd_, RealFocal, Reverse);
+    const lfLensCalibDistortion lcd = rescale_polynomial_coefficients (lcd_, RealFocal, Reverse, &scaling_d);
     if (Reverse)
         switch (lcd.Model)
         {
@@ -459,6 +462,8 @@ float lfModifier::GetAutoScale (bool reverse)
     // that we really have no black borders left.
     scale *= 1.001;
     scale *= subpixel_scale;
+    
+    scale *= scaling_d;
 
     return reverse ? 1.0 / scale : scale;
 }

--- a/libs/lensfun/modifier.cpp
+++ b/libs/lensfun/modifier.cpp
@@ -111,6 +111,7 @@ void lfModifier::Destroy ()
 lfModifier::lfModifier (const lfLens*, float crop, int width, int height)
 {
     Crop = crop;
+    scaling_d = 1.0;
 
     // Avoid divide overflows on singular cases.  The "- 1" is due to the fact
     // that `Width` and `Height` are measured at the pixel centres (they are
@@ -123,7 +124,7 @@ lfModifier::lfModifier (const lfLens*, float crop, int width, int height)
 
 lfModifier::lfModifier (const lfLens *lens, float imgfocal, float imgcrop, int imgwidth, int imgheight,
                         lfPixelFormat pixel_format, bool reverse /* = false */)
-    : Crop(imgcrop), Focal(imgfocal), Reverse(reverse), PixelFormat(pixel_format), Lens(lens)
+    : Crop(imgcrop), Focal(imgfocal), Reverse(reverse), PixelFormat(pixel_format), Lens(lens), scaling_d(1.0)
 {
     // Avoid divide overflows on singular cases.  The "- 1" is due to the fact
     // that `Width` and `Height` are measured at the pixel centres (they are
@@ -162,6 +163,9 @@ int lfModifier::EnableScaling (float scale)
         if (scale == 0.0)
             return false;
     }
+    
+    // backward compatibility to 0.3.2
+    scale /= scaling_d;
 
     lfCoordScaleCallbackData* cd = new lfCoordScaleCallbackData;
 


### PR DESCRIPTION
I changes the scaling factor in the API back to the meaning of 0.3.2 release as demanded by issue #945 .

I exemplarily verified it for a fake lens with very high distortion:
[test_scaling.zip](https://github.com/lensfun/lensfun/files/4604203/test_scaling.zip)

Still, there are very small differences left over (about 1 pixel) but they seem to come from further changes, e.g., the center of the image has changed since 0.3.2 a tiny bit. 
