### PR TITLE
Add vignetting correction for Nikkor Z 24-70 f/4 S

### DIFF
--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -291,6 +291,57 @@
             <tca model="poly3" focal="35" vr="1.0000506" vb="1.0001152"/>
             <tca model="poly3" focal="50" vr="0.9999946" vb="1.0000632"/>
             <tca model="poly3" focal="70" vr="0.9999059" vb="0.9999643"/>
+            <!-- Taken with Nikon Z6 -->
+            <vignetting model="pa" focal="24.0" aperture="4.0" distance="10" k1="-0.4443301" k2="-0.8757330" k3="0.4629641" />
+            <vignetting model="pa" focal="24.0" aperture="4.0" distance="1000" k1="-0.4443301" k2="-0.8757330" k3="0.4629641" />
+            <vignetting model="pa" focal="24.0" aperture="5.6" distance="10" k1="-0.6482147" k2="-0.0472485" k3="-0.0642677" />
+            <vignetting model="pa" focal="24.0" aperture="5.6" distance="1000" k1="-0.6482147" k2="-0.0472485" k3="-0.0642677" />
+            <vignetting model="pa" focal="24.0" aperture="8.0" distance="10" k1="-0.6578518" k2="-0.1161517" k3="0.1095337" />
+            <vignetting model="pa" focal="24.0" aperture="8.0" distance="1000" k1="-0.6578518" k2="-0.1161517" k3="0.1095337" />
+            <vignetting model="pa" focal="24.0" aperture="11.0" distance="10" k1="-0.6197886" k2="-0.3217191" k3="0.3238373" />
+            <vignetting model="pa" focal="24.0" aperture="11.0" distance="1000" k1="-0.6197886" k2="-0.3217191" k3="0.3238373" />
+            <vignetting model="pa" focal="24.0" aperture="22.0" distance="10" k1="-0.5014912" k2="-0.4995200" k3="0.4113183" />
+            <vignetting model="pa" focal="24.0" aperture="22.0" distance="1000" k1="-0.5014912" k2="-0.4995200" k3="0.4113183" />
+            <vignetting model="pa" focal="28.0" aperture="4.0" distance="10" k1="-0.3718631" k2="-0.9318504" k3="0.6048719" />
+            <vignetting model="pa" focal="28.0" aperture="4.0" distance="1000" k1="-0.3718631" k2="-0.9318504" k3="0.6048719" />
+            <vignetting model="pa" focal="28.0" aperture="5.6" distance="10" k1="-0.4570521" k2="-0.3860115" k3="0.1850579" />
+            <vignetting model="pa" focal="28.0" aperture="5.6" distance="1000" k1="-0.4570521" k2="-0.3860115" k3="0.1850579" />
+            <vignetting model="pa" focal="28.0" aperture="8.0" distance="10" k1="-0.5697124" k2="-0.0975593" k3="0.0678084" />
+            <vignetting model="pa" focal="28.0" aperture="8.0" distance="1000" k1="-0.5697124" k2="-0.0975593" k3="0.0678084" />
+            <vignetting model="pa" focal="28.0" aperture="11.0" distance="10" k1="-0.5323665" k2="-0.2947430" k3="0.2789542" />
+            <vignetting model="pa" focal="28.0" aperture="11.0" distance="1000" k1="-0.5323665" k2="-0.2947430" k3="0.2789542" />
+            <vignetting model="pa" focal="28.0" aperture="22.0" distance="10" k1="-0.4361415" k2="-0.4515922" k3="0.3679098" />
+            <vignetting model="pa" focal="28.0" aperture="22.0" distance="1000" k1="-0.4361415" k2="-0.4515922" k3="0.3679098" />
+            <vignetting model="pa" focal="34.5" aperture="4.0" distance="10" k1="-0.3397245" k2="-0.8805424" k3="0.6013240" />
+            <vignetting model="pa" focal="34.5" aperture="4.0" distance="1000" k1="-0.3397245" k2="-0.8805424" k3="0.6013240" />
+            <vignetting model="pa" focal="34.5" aperture="5.6" distance="10" k1="-0.3739464" k2="-0.2778535" k3="0.0778164" />
+            <vignetting model="pa" focal="34.5" aperture="5.6" distance="1000" k1="-0.3739464" k2="-0.2778535" k3="0.0778164" />
+            <vignetting model="pa" focal="34.5" aperture="8.0" distance="10" k1="-0.4893736" k2="-0.0042425" k3="-0.0161347" />
+            <vignetting model="pa" focal="34.5" aperture="8.0" distance="1000" k1="-0.4893736" k2="-0.0042425" k3="-0.0161347" />
+            <vignetting model="pa" focal="34.5" aperture="11.0" distance="10" k1="-0.4237889" k2="-0.2560042" k3="0.2244748" />
+            <vignetting model="pa" focal="34.5" aperture="11.0" distance="1000" k1="-0.4237889" k2="-0.2560042" k3="0.2244748" />
+            <vignetting model="pa" focal="34.5" aperture="22.0" distance="10" k1="-0.3960898" k2="-0.2947470" k3="0.2490447" />
+            <vignetting model="pa" focal="34.5" aperture="22.0" distance="1000" k1="-0.3960898" k2="-0.2947470" k3="0.2490447" />
+            <vignetting model="pa" focal="50.0" aperture="4.0" distance="10" k1="-0.4901334" k2="-0.1517376" k3="0.0889762" />
+            <vignetting model="pa" focal="50.0" aperture="4.0" distance="1000" k1="-0.4901334" k2="-0.1517376" k3="0.0889762" />
+            <vignetting model="pa" focal="50.0" aperture="5.6" distance="10" k1="-0.2447861" k2="-0.2477095" k3="0.0419547" />
+            <vignetting model="pa" focal="50.0" aperture="5.6" distance="1000" k1="-0.2447861" k2="-0.2477095" k3="0.0419547" />
+            <vignetting model="pa" focal="50.0" aperture="8.0" distance="10" k1="-0.3448420" k2="-0.0069534" k3="-0.0263308" />
+            <vignetting model="pa" focal="50.0" aperture="8.0" distance="1000" k1="-0.3448420" k2="-0.0069534" k3="-0.0263308" />
+            <vignetting model="pa" focal="50.0" aperture="11.0" distance="10" k1="-0.2914087" k2="-0.2187803" k3="0.1883851" />
+            <vignetting model="pa" focal="50.0" aperture="11.0" distance="1000" k1="-0.2914087" k2="-0.2187803" k3="0.1883851" />
+            <vignetting model="pa" focal="50.0" aperture="22.0" distance="10" k1="-0.2861722" k2="-0.2221781" k3="0.1877337" />
+            <vignetting model="pa" focal="50.0" aperture="22.0" distance="1000" k1="-0.2861722" k2="-0.2221781" k3="0.1877337" />
+            <vignetting model="pa" focal="70.0" aperture="4.0" distance="10" k1="-0.5974678" k2="0.3024944" k3="-0.4322144" />
+            <vignetting model="pa" focal="70.0" aperture="4.0" distance="1000" k1="-0.5974678" k2="0.3024944" k3="-0.4322144" />
+            <vignetting model="pa" focal="70.0" aperture="5.6" distance="10" k1="-0.2655728" k2="0.1325074" k3="-0.4145619" />
+            <vignetting model="pa" focal="70.0" aperture="5.6" distance="1000" k1="-0.2655728" k2="0.1325074" k3="-0.4145619" />
+            <vignetting model="pa" focal="70.0" aperture="8.0" distance="10" k1="-0.3521749" k2="0.2507118" k3="-0.2609059" />
+            <vignetting model="pa" focal="70.0" aperture="8.0" distance="1000" k1="-0.3521749" k2="0.2507118" k3="-0.2609059" />
+            <vignetting model="pa" focal="70.0" aperture="11.0" distance="10" k1="-0.2480068" k2="-0.1645881" k3="0.1456365" />
+            <vignetting model="pa" focal="70.0" aperture="11.0" distance="1000" k1="-0.2480068" k2="-0.1645881" k3="0.1456365" />
+            <vignetting model="pa" focal="70.0" aperture="22.0" distance="10" k1="-0.2555569" k2="-0.1340241" k3="0.1268382" />
+            <vignetting model="pa" focal="70.0" aperture="22.0" distance="1000" k1="-0.2555569" k2="-0.1340241" k3="0.1268382" />
         </calibration>
     </lens>
 


### PR DESCRIPTION
This adds vignetting calibration data for a Nikkor Z 24-70 f/4 S.

Shots were taken on this cloudy morning with a Nikon Z6.
I have verified the applied correction using darktable git master (3.1.0+2411)
and results look promising to me.

The generated PDF report is too large for attaching it here.