### PR TITLE
Add vignetting correction for Nikkor Z 85mm f/1.8 S

### DIFF
--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -313,6 +313,7 @@
             <tca model="poly3" focal="70" vr="0.9998371" vb="0.9999660"/>
         </calibration>
     </lens>
+
     <lens>
         <maker>Nikon</maker>
         <model>NIKKOR Z 85mm f/1.8 S</model>

--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -313,5 +313,28 @@
             <tca model="poly3" focal="70" vr="0.9998371" vb="0.9999660"/>
         </calibration>
     </lens>
+    <lens>
+        <maker>Nikon</maker>
+        <model>NIKKOR Z 85mm f/1.8 S</model>
+        <mount>Nikon Z</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+            <!-- Taken with Nikon Z6 -->
+            <vignetting model="pa" focal="85.0" aperture="1.8" distance="10" k1="-0.8779320" k2="0.2895851" k3="-0.0092442" />
+            <vignetting model="pa" focal="85.0" aperture="1.8" distance="1000" k1="-0.8779320" k2="0.2895851" k3="-0.0092442" />
+            <vignetting model="pa" focal="85.0" aperture="2.0" distance="10" k1="-0.6108530" k2="-0.0716128" k3="0.0995779" />
+            <vignetting model="pa" focal="85.0" aperture="2.0" distance="1000" k1="-0.6108530" k2="-0.0716128" k3="0.0995779" />
+            <vignetting model="pa" focal="85.0" aperture="2.8" distance="10" k1="-0.0848127" k2="-0.2032208" k3="-0.0392958" />
+            <vignetting model="pa" focal="85.0" aperture="2.8" distance="1000" k1="-0.0848127" k2="-0.2032208" k3="-0.0392958" />
+            <vignetting model="pa" focal="85.0" aperture="4.0" distance="10" k1="-0.1792456" k2="0.0743969" k3="-0.0795954" />
+            <vignetting model="pa" focal="85.0" aperture="4.0" distance="1000" k1="-0.1792456" k2="0.0743969" k3="-0.0795954" />
+            <vignetting model="pa" focal="85.0" aperture="5.6" distance="10" k1="-0.1403628" k2="-0.0870986" k3="0.0700312" />
+            <vignetting model="pa" focal="85.0" aperture="5.6" distance="1000" k1="-0.1403628" k2="-0.0870986" k3="0.0700312" />
+            <vignetting model="pa" focal="85.0" aperture="8.0" distance="10" k1="-0.1427479" k2="-0.1008813" k3="0.0902056" />
+            <vignetting model="pa" focal="85.0" aperture="8.0" distance="1000" k1="-0.1427479" k2="-0.1008813" k3="0.0902056" />
+            <vignetting model="pa" focal="85.0" aperture="16.0" distance="10" k1="-0.1030326" k2="-0.0395645" k3="0.0316660" />
+            <vignetting model="pa" focal="85.0" aperture="16.0" distance="1000" k1="-0.1030326" k2="-0.0395645" k3="0.0316660" />
+        </calibration>
+    </lens>
 
 </lensdatabase>

--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -320,6 +320,8 @@
         <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken with Nikon Z6 -->
+            <distortion model="ptlens" focal="85.0" a="-0.006" b="0.023" c="-0.028" />
+            <tca model="poly3" focal="85.0" br="-0.0000217" vr="1.0000357" bb="0.0000030" vb="0.9999613" />
             <vignetting model="pa" focal="85.0" aperture="1.8" distance="10" k1="-0.8779320" k2="0.2895851" k3="-0.0092442" />
             <vignetting model="pa" focal="85.0" aperture="1.8" distance="1000" k1="-0.8779320" k2="0.2895851" k3="-0.0092442" />
             <vignetting model="pa" focal="85.0" aperture="2.0" distance="10" k1="-0.6108530" k2="-0.0716128" k3="0.0995779" />


### PR DESCRIPTION
This adds a new section to the lens database and for
the moment just vignetting calibration data for a Nikkor Z 85mm f/1.8 S.

Shots were taken on this cloudy morning with a Nikon Z6.
I have verified the applied correction using darktable git master (3.1.0+2411)
and results look promising to me.

Distortion and TCA will follow some day when I'm able to find
suitable conditions according to the calibration processes.

Signed-off-by: René Kowalke <rene.kowalke@gmail.com>