### PR TITLE
Add Canon EOS 250D / Rebel SL3 body

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -604,6 +604,22 @@
 
     <camera>
         <maker>Canon</maker>
+        <model>Canon EOS 250D</model>
+        <model lang="en">EOS 250D</model>
+        <mount>Canon EF-S</mount>
+        <cropfactor>1.613</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS REBEL SL3</model>
+        <model lang="en">EOS Rebel SL3</model>
+        <mount>Canon EF-S</mount>
+        <cropfactor>1.613</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
         <model>Canon EOS Kiss X9</model>
         <model lang="en">EOS Kiss X9</model>
         <mount>Canon EF-S</mount>


### PR DESCRIPTION
The body is identical to 200D, so this is a simple copy-paste from the entries above.

I've verified that this change works locally with darktable and automatically recognises images from my camera, whereas before I always had to manually choose 200D instead.