### PR TITLE
Uchrisu patch nikkor24 1.8

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,7 @@ New interchangeable lenses:
 * Nikon AI-S Nikkor 105mm f/2.5
 * Nikon AF-S 200-500mm f/5.6E ED VR
 * Nikon Z 24-200mm f/4-6.3 VR
+* Nikon AF-S Nikkor 24mm f/1.8G ED
 * Olympus M.Zuiko Digital 17mm f/1.2
 * Olympus M.Zuiko Digital 25mm f/1.2
 * Olympus M.Zuiko ED 30mm f/3.5 Macro

--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -4865,5 +4865,17 @@
             <tca model="poly3" focal="35" vr="1.0001831" vb="1.0000038"/>
         </calibration>
     </lens>
+    
+    <lens>
+        <maker>Nikon</maker>
+        <model>Nikon AF-S Nikkor 24mm f/1.8G ED</model>
+        <mount>Nikon F AF</mount>
+        <cropfactor>1.001</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="24" a="0.000860596845977449" b="0.0002663127335183226" c="-0.020873127333617125"/>
+            <tca model="poly3" focal="24" vr="1.0002163" vb="0.9999614"/>
+        </calibration>
+    </lens>
+
 
 </lensdatabase>

--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -4896,6 +4896,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 24mm f/1.8G ED</model>
+        <model lang="en">Nikkor AF-S 24mm f/1.8G ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.001</cropfactor>
         <calibration>


### PR DESCRIPTION
TCA and Distortion thanks to #1178

The name detected by calibrate.py  and darktable did not coincide. I took the one of darktable now.
Both versions were somehow different from the conventional Nikon lens naming. 

I would suggest to take the darktable-compatible name