### PR TITLE
Added different naming for same lens Canon EF 24-105mm f/4L IS 

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -2005,6 +2005,152 @@
 
     <lens>
         <maker>Canon</maker>
+        <model>Canon EF 24-105mm f/4L IS</model>
+        <mount>Canon EF</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="24" a="0.017263" b="-0.049244" c="0"/>
+            <distortion model="ptlens" focal="28" a="0.010878" b="-0.024454" c="0"/>
+            <distortion model="ptlens" focal="35" a="0.007152" b="-0.009799" c="0"/>
+            <distortion model="ptlens" focal="50" a="0.002502" b="0.004803" c="0"/>
+            <distortion model="ptlens" focal="70" a="0" b="0.009685" c="0"/>
+            <distortion model="ptlens" focal="88" a="0" b="0.008781" c="0"/>
+            <distortion model="ptlens" focal="105" a="0" b="0.009598" c="0"/>
+            <!-- Taken with Canon 5D Mark III -->
+            <tca model="poly3" focal="24" br="-0.0000336" vr="1.0011673" bb="-0.0000857" vb="1.0001820"/>
+            <tca model="poly3" focal="28" br="-0.0000198" vr="1.0009538" bb="-0.0000780" vb="1.0001947"/>
+            <tca model="poly3" focal="35" br="0.0000238" vr="1.0006733" bb="-0.0000900" vb="1.0002139"/>
+            <tca model="poly3" focal="45" br="0.0000790" vr="1.0003749" bb="-0.0000725" vb="1.0001305"/>
+            <tca model="poly3" focal="50" br="0.0000550" vr="1.0001985" bb="-0.0001125" vb="1.0000939"/>
+            <tca model="poly3" focal="60" br="0.0000537" vr="0.9999940" bb="-0.0001371" vb="1.0000645"/>
+            <tca model="poly3" focal="70" br="0.0000545" vr="0.9998413" bb="-0.0001606" vb="0.9999358"/>
+            <tca model="poly3" focal="88" br="0.0000129" vr="0.9995321" bb="-0.0002706" vb="0.9999391"/>
+            <tca model="poly3" focal="105" br="0.0000381" vr="0.9991735" bb="-0.0001974" vb="0.9998595"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="0.45" k1="-0.4795" k2="-0.5164" k3="0.1168"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="0.9" k1="-0.5099" k2="-0.3593" k3="0.0100"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="2.7" k1="-0.5210" k2="-0.3005" k3="-0.0331"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="1000" k1="-0.5460" k2="-0.2245" k3="-0.0825"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="0.45" k1="-0.5434" k2="-0.0220" k3="-0.2734"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="0.9" k1="-0.5925" k2="0.1920" k3="-0.4102"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="2.7" k1="-0.6105" k2="0.2702" k3="-0.4657"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="1000" k1="-0.6251" k2="0.3124" k3="-0.4911"/>
+            <vignetting model="pa" focal="24" aperture="8" distance="0.45" k1="-0.7341" k2="0.6702" k3="-0.7376"/>
+            <vignetting model="pa" focal="24" aperture="8" distance="0.9" k1="-0.7582" k2="0.7674" k3="-0.7682"/>
+            <vignetting model="pa" focal="24" aperture="8" distance="2.7" k1="-0.7783" k2="0.8378" k3="-0.8121"/>
+            <vignetting model="pa" focal="24" aperture="8" distance="1000" k1="-0.7823" k2="0.8454" k3="-0.8131"/>
+            <vignetting model="pa" focal="24" aperture="11" distance="0.45" k1="-0.8706" k2="1.1062" k3="-1.0123"/>
+            <vignetting model="pa" focal="24" aperture="11" distance="0.9" k1="-0.8371" k2="0.9860" k3="-0.8679"/>
+            <vignetting model="pa" focal="24" aperture="11" distance="2.7" k1="-0.8344" k2="0.9810" k3="-0.8608"/>
+            <vignetting model="pa" focal="24" aperture="11" distance="1000" k1="-0.8340" k2="0.9778" k3="-0.8568"/>
+            <vignetting model="pa" focal="24" aperture="16" distance="0.45" k1="-0.9126" k2="1.2016" k3="-1.0358"/>
+            <vignetting model="pa" focal="24" aperture="16" distance="0.9" k1="-0.8199" k2="0.8728" k3="-0.7322"/>
+            <vignetting model="pa" focal="24" aperture="16" distance="2.7" k1="-0.8124" k2="0.8533" k3="-0.7189"/>
+            <vignetting model="pa" focal="24" aperture="16" distance="1000" k1="-0.8099" k2="0.8471" k3="-0.7154"/>
+            <vignetting model="pa" focal="24" aperture="22" distance="0.45" k1="-0.8999" k2="1.1258" k3="-0.9507"/>
+            <vignetting model="pa" focal="24" aperture="22" distance="0.9" k1="-0.7940" k2="0.7596" k3="-0.6258"/>
+            <vignetting model="pa" focal="24" aperture="22" distance="2.7" k1="-0.8030" k2="0.8024" k3="-0.6672"/>
+            <vignetting model="pa" focal="24" aperture="22" distance="1000" k1="-0.8041" k2="0.8095" k3="-0.6743"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.45" k1="-0.5671" k2="-0.1074" k3="0.0934"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="0.9" k1="-0.5570" k2="-0.0974" k3="0.0827"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="2.7" k1="-0.5699" k2="-0.0408" k3="0.0282"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="1000" k1="-0.6054" k2="0.0282" k3="-0.0163"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.45" k1="-0.6116" k2="0.3685" k3="-0.2226"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="0.9" k1="-0.6017" k2="0.3878" k3="-0.2407"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="2.7" k1="-0.6215" k2="0.4488" k3="-0.2954"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="1000" k1="-0.6418" k2="0.5034" k3="-0.3355"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.45" k1="-0.5971" k2="0.3002" k3="-0.1550"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="0.9" k1="-0.5770" k2="0.2770" k3="-0.1328"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="2.7" k1="-0.5849" k2="0.2941" k3="-0.1483"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="1000" k1="-0.6029" k2="0.3432" k3="-0.1836"/>
+            <vignetting model="pa" focal="35" aperture="11" distance="0.45" k1="-0.5999" k2="0.2956" k3="-0.1444"/>
+            <vignetting model="pa" focal="35" aperture="11" distance="0.9" k1="-0.5764" k2="0.2640" k3="-0.1160"/>
+            <vignetting model="pa" focal="35" aperture="11" distance="2.7" k1="-0.5843" k2="0.2767" k3="-0.1257"/>
+            <vignetting model="pa" focal="35" aperture="11" distance="1000" k1="-0.6005" k2="0.3196" k3="-0.1558"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.45" k1="-0.6063" k2="0.2984" k3="-0.1399"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="0.9" k1="-0.5833" k2="0.2700" k3="-0.1142"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="2.7" k1="-0.5913" k2="0.2812" k3="-0.1221"/>
+            <vignetting model="pa" focal="35" aperture="16" distance="1000" k1="-0.6041" k2="0.3158" k3="-0.1462"/>
+            <vignetting model="pa" focal="35" aperture="22" distance="0.45" k1="-0.6122" k2="0.3065" k3="-0.1424"/>
+            <vignetting model="pa" focal="35" aperture="22" distance="0.9" k1="-0.5894" k2="0.2778" k3="-0.1160"/>
+            <vignetting model="pa" focal="35" aperture="22" distance="2.7" k1="-0.5972" k2="0.2887" k3="-0.1240"/>
+            <vignetting model="pa" focal="35" aperture="22" distance="1000" k1="-0.6070" k2="0.3145" k3="-0.1413"/>
+            <vignetting model="pa" focal="50" aperture="4" distance="0.45" k1="-0.5274" k2="-0.2110" k3="0.2123"/>
+            <vignetting model="pa" focal="50" aperture="4" distance="0.9" k1="-0.5559" k2="-0.0930" k3="0.1107"/>
+            <vignetting model="pa" focal="50" aperture="4" distance="2.7" k1="-0.5569" k2="-0.0746" k3="0.0868"/>
+            <vignetting model="pa" focal="50" aperture="4" distance="1000" k1="-0.5818" k2="-0.0162" k3="0.0425"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="0.45" k1="-0.3835" k2="0.0297" k3="-0.0329"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="0.9" k1="-0.5182" k2="0.3503" k3="-0.2346"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="2.7" k1="-0.5279" k2="0.3888" k3="-0.2717"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="1000" k1="-0.5500" k2="0.4475" k3="-0.3184"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="0.45" k1="-0.4861" k2="0.1556" k3="-0.0270"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="0.9" k1="-0.4743" k2="0.1487" k3="-0.0198"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="2.7" k1="-0.4674" k2="0.1258" k3="-0.0020"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="1000" k1="-0.4889" k2="0.1737" k3="-0.0356"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="0.45" k1="-0.4856" k2="0.1481" k3="-0.0178"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="0.9" k1="-0.4750" k2="0.1425" k3="-0.0101"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="2.7" k1="-0.4685" k2="0.1214" k3="0.0057"/>
+            <vignetting model="pa" focal="50" aperture="11" distance="1000" k1="-0.4893" k2="0.1670" k3="-0.0255"/>
+            <vignetting model="pa" focal="50" aperture="16" distance="0.45" k1="-0.4905" k2="0.1537" k3="-0.0187"/>
+            <vignetting model="pa" focal="50" aperture="16" distance="0.9" k1="-0.4771" k2="0.1396" k3="-0.0042"/>
+            <vignetting model="pa" focal="50" aperture="16" distance="2.7" k1="-0.4751" k2="0.1298" k3="0.0038"/>
+            <vignetting model="pa" focal="50" aperture="16" distance="1000" k1="-0.4944" k2="0.1721" k3="-0.0253"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="0.45" k1="-0.5000" k2="0.1707" k3="-0.0276"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="0.9" k1="-0.4836" k2="0.1490" k3="-0.0077"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="2.7" k1="-0.4846" k2="0.1454" k3="-0.0035"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="1000" k1="-0.5030" k2="0.1854" k3="-0.0309"/>
+            <vignetting model="pa" focal="70" aperture="4" distance="0.45" k1="-0.7049" k2="0.2950" k3="-0.1500"/>
+            <vignetting model="pa" focal="70" aperture="4" distance="0.9" k1="-0.7163" k2="0.3620" k3="-0.2250"/>
+            <vignetting model="pa" focal="70" aperture="4" distance="2.7" k1="-0.6962" k2="0.3204" k3="-0.2129"/>
+            <vignetting model="pa" focal="70" aperture="4" distance="1000" k1="-0.7079" k2="0.3344" k3="-0.2278"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="0.45" k1="-0.4799" k2="0.3668" k3="-0.2925"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="0.9" k1="-0.4831" k2="0.4338" k3="-0.3717"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="2.7" k1="-0.4805" k2="0.4500" k3="-0.3919"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="-0.5016" k2="0.4991" k3="-0.4414"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="0.45" k1="-0.4273" k2="0.1139" k3="0.0043"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="0.9" k1="-0.4138" k2="0.1045" k3="0.0093"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="2.7" k1="-0.4064" k2="0.0883" k3="0.0218"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.4297" k2="0.1397" k3="-0.0142"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="0.45" k1="-0.4280" k2="0.1093" k3="0.0114"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="0.9" k1="-0.4061" k2="0.0772" k3="0.0344"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="2.7" k1="-0.3995" k2="0.0578" k3="0.0519"/>
+            <vignetting model="pa" focal="70" aperture="11" distance="1000" k1="-0.4207" k2="0.1038" k3="0.0199"/>
+            <vignetting model="pa" focal="70" aperture="16" distance="0.45" k1="-0.4290" k2="0.1066" k3="0.0159"/>
+            <vignetting model="pa" focal="70" aperture="16" distance="0.9" k1="-0.4079" k2="0.0761" k3="0.0380"/>
+            <vignetting model="pa" focal="70" aperture="16" distance="2.7" k1="-0.4021" k2="0.0578" k3="0.0551"/>
+            <vignetting model="pa" focal="70" aperture="16" distance="1000" k1="-0.4222" k2="0.1029" k3="0.0231"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="0.45" k1="-0.4335" k2="0.1101" k3="0.0166"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="0.9" k1="-0.4124" k2="0.0813" k3="0.0370"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="2.7" k1="-0.4081" k2="0.0661" k3="0.0521"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="1000" k1="-0.4296" k2="0.1152" k3="0.0173"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="0.45" k1="-1.0812" k2="1.1713" k3="-0.6459"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="0.9" k1="-1.0310" k2="1.0659" k3="-0.6301"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="2.7" k1="-0.9948" k2="0.9010" k3="-0.5254"/>
+            <vignetting model="pa" focal="105" aperture="4" distance="1000" k1="-1.0176" k2="0.8667" k3="-0.4856"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="0.45" k1="-0.3223" k2="-0.0995" k3="0.0451"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="0.9" k1="-0.3340" k2="-0.0051" k3="-0.0805"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="2.7" k1="-0.3113" k2="-0.0072" k3="-0.1158"/>
+            <vignetting model="pa" focal="105" aperture="5.6" distance="1000" k1="-0.3111" k2="-0.0112" k3="-0.1305"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="0.45" k1="-0.3740" k2="0.0834" k3="0.0276"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="0.9" k1="-0.3449" k2="0.0346" k3="0.0606"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="2.7" k1="-0.3473" k2="0.0666" k3="0.0265"/>
+            <vignetting model="pa" focal="105" aperture="8" distance="1000" k1="-0.3824" k2="0.1623" k3="-0.0510"/>
+            <vignetting model="pa" focal="105" aperture="11" distance="0.45" k1="-0.3703" k2="0.0630" k3="0.0486"/>
+            <vignetting model="pa" focal="105" aperture="11" distance="0.9" k1="-0.3403" k2="0.0180" k3="0.0758"/>
+            <vignetting model="pa" focal="105" aperture="11" distance="2.7" k1="-0.3352" k2="0.0101" k3="0.0818"/>
+            <vignetting model="pa" focal="105" aperture="11" distance="1000" k1="-0.3508" k2="0.0342" k3="0.0673"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="0.45" k1="-0.3726" k2="0.0649" k3="0.0487"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="0.9" k1="-0.3408" k2="0.0156" k3="0.0789"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="2.7" k1="-0.3371" k2="0.0090" k3="0.0856"/>
+            <vignetting model="pa" focal="105" aperture="16" distance="1000" k1="-0.3511" k2="0.0307" k3="0.0728"/>
+            <vignetting model="pa" focal="105" aperture="22" distance="0.45" k1="-0.3752" k2="0.0669" k3="0.0488"/>
+            <vignetting model="pa" focal="105" aperture="22" distance="0.9" k1="-0.3442" k2="0.0175" k3="0.0798"/>
+            <vignetting model="pa" focal="105" aperture="22" distance="2.7" k1="-0.3422" k2="0.0150" k3="0.0838"/>
+            <vignetting model="pa" focal="105" aperture="22" distance="1000" k1="-0.3540" k2="0.0313" k3="0.0746"/>
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Canon</maker>
         <model>Canon EF 24-105mm f/4L IS USM</model>
         <mount>Canon EF</mount>
         <!-- Average crop factor of Canon APS-C cameras -->


### PR DESCRIPTION
Canon lens appears as "Canon EF 24-105mm f/4L IS USM" and it's correct.
However it seems than sometimes (maybe different production batches of the same lens) it appears as "Canon EF 24-105mm f/4L IS"
This IS lens ALWAYS has USM, so it is the same lens. I copied the values of "Canon EF 24-105mm f/4L IS USM"  into the new lens "Canon EF 24-105mm f/4L IS" 

Some exiv2 extracts:
Exif.Canon.LensModel                         Ascii      74  EF24-105mm f/4L IS USM
Exif.CanonCs.LensType                        Short       1  Canon EF 24-105mm f/4L IS
