### PR TITLE
Update mil-panasonic.xml

### DIFF
--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -228,6 +228,46 @@
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
     </camera>
+	
+    <!-- Added by ExpPhysU on 2020-12-12. -->	
+    <!-- Source: https://www.dpreview.com/reviews/buying-guide-best-cameras-under-1500/9  and my own camera DC-G91-->
+    <camera>
+        <maker>Panasonic</maker>
+        <model>DC-G90</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+    
+    <!-- Added by ExpPhysU on 2020-12-12. -->	
+    <camera>
+	 <!-- Alias for the DC-G90. -->
+	 <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name-->
+        <maker>Panasonic</maker>
+        <model>DC-G91</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+    
+    <!-- Added by ExpPhysU on 2020-12-12. -->	
+    <camera>
+	 <!-- Alias for the DC-G90. -->
+	 <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name-->
+        <maker>Panasonic</maker>
+        <model>DC-G95</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+    
+    <!-- Added by ExpPhysU on 2020-12-12. -->	
+    <camera>
+	 <!-- Alias for the DC-G90. -->
+	 <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name-->
+        <maker>Panasonic</maker>
+        <model>DC-G99</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+ 
 
     <camera>
         <maker>Panasonic</maker>


### PR DESCRIPTION
My camera Panasonic Lumix DC-G91 was missing. DPReview.com (https://www.dpreview.com/reviews/buying-guide-best-cameras-under-1500/9) states, that the camera is sold under four names (DC-G90, DC-G91, DC-G95 and DC-G99). I marked my changes by the comment <!-- Added by ExpPhysU on 2020-12-12. -->
I kindly ask you to consider my additions for inclusion.
Othmar Marti (ExpPhysU)