### PR TITLE
Update slr-canon.xml. Added secondary name to lens

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -1860,6 +1860,7 @@
     <lens>
         <maker>Canon</maker>
         <model>Canon EF 24-105mm f/4L IS USM</model>
+        <model lang="en">Canon EF 24-105mm f/4L IS</model>
         <mount>Canon EF</mount>
         <cropfactor>1</cropfactor>
         <calibration>


### PR DESCRIPTION
[Corrects Issue 1281](https://github.com/lensfun/lensfun/issues/1281). 

Canon lens appears as "Canon EF 24-105mm f/4L IS USM" and it's correct.
However it seems than sometimes (maybe different production batches of the same lens) it appears as "Canon EF 24-105mm f/4L IS"
This IS lens ALWAYS has USM, so it is the same lens. I copied the values of "Canon EF 24-105mm f/4L IS USM" into the new lens "Canon EF 24-105mm f/4L IS"

Some exiv2 extracts:
Exif.Canon.LensModel Ascii 74 EF24-105mm f/4L IS USM
Exif.CanonCs.LensType Short 1 Canon EF 24-105mm f/4L IS

