### PR TITLE
Fix model for Sigma 30mm f/1.4 DC DN C 016

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -184,7 +184,7 @@
 
     <lens>
         <maker>Sigma</maker>
-        <model>SIGMA 30mm f/1.4 DC DN | C 016</model>
+        <model>SIGMA 30mm f/1.4 DC DN | Contemporary 016</model>
         <model lang="en">30mm f/1.4 DC DN</model>
         <mount>Sony E</mount>
         <mount>Micro 4/3 System</mount>


### PR DESCRIPTION
Hi,

darktable did not detect the lens automatically, it's reported in darktable with "Contemporary" spelled out. I simply changed the model in mil-sigma.xml .

**Before the patch** 
![darktable_lens_not_detected](https://user-images.githubusercontent.com/6408150/104056802-59c54200-51f1-11eb-9490-142ec6bcc1d9.png)

**After the patch** 
![dartable_lens_fixed](https://user-images.githubusercontent.com/6408150/104056820-6184e680-51f1-11eb-9161-fba5c38f3e8e.png)

