### PR TITLE
Update slr-pentax.xml

### DIFF
--- a/data/db/slr-pentax.xml
+++ b/data/db/slr-pentax.xml
@@ -276,7 +276,7 @@
         <maker lang="en">Pentax</maker>
         <model>Pentax K-1</model>
         <model lang="en">K-1</model>
-        <mount>Pentax KAF3</mount>
+        <mount>Pentax KAF4</mount>
         <cropfactor>1</cropfactor>
     </camera>
 
@@ -285,7 +285,7 @@
         <maker lang="en">Pentax</maker>
         <model>PENTAX K-1 Mark II</model>
         <model lang="en">K-1 Mark II</model>
-        <mount>Pentax KAF3</mount>
+        <mount>Pentax KAF4</mount>
         <cropfactor>1.0</cropfactor>
     </camera>
 


### PR DESCRIPTION
"Pentax K-1" and "Pentax K-1 mark II" have a KAF4 mount and is compatible with all old version of K mount. The main difference between KAF3 and KAF4 is electromagnetic diaphragm control system on KAF4.