### PR TITLE
Update misc.xml

### DIFF
--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -512,7 +512,7 @@
         <model>Irix 15mm f/2.4</model>
         <mount>Canon EF</mount>
         <mount>Nikon F</mount>
-        <mount>Pentax KAF</mount>
+        <mount>Pentax KA</mount>
         <aperture min="2.4" max="22"/>
         <cropfactor>1</cropfactor>
         <calibration>


### PR DESCRIPTION
Irix lenses has a Pentax KA2 mount, not KAF but KA2 is not on "lensfun/data/db/slr-pentax.xml" so the near mount is Pentax KA..