### PR TITLE
Fix names of two lenses

### DIFF
--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -4671,7 +4671,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>Nikon AF-P DX Nikkor 10-20mm f/4.5-5.6 VR 168</model>
+        <model>Nikon AF-P DX Nikkor 10-20mm f/4.5-5.6G VR 168</model>
         <model lang="en">Nikkor AF-P 10-20mm f/4.5-5.6G DX VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>

--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -860,7 +860,7 @@
 
     <lens>
         <maker>Tamron</maker>
-        <model>Tamron SP 70-300mm f/4.0-5.6 Di VC USD (A005)</model>
+        <model>Tamron SP 70-300mm f/4-5.6 Di VC USD (A005)</model>
         <mount>Canon EF</mount>
         <mount>Nikon F AF</mount>
         <mount>Sony Alpha</mount>


### PR DESCRIPTION
As reported by Johann Maierhofer, the names
  Nikon AF-P DX Nikkor 10-20mm f/4.5-5.6G VR 168
  Tamron SP 70-300mm f/4-5.6 Di VC USD (A005)
were slightly inconsistent with those reported from exif. (Missing 'G', and '4.0' in place of '4', respectively).