### PR TITLE
Add Fuji X100V

### DIFF
--- a/data/db/compact-fujifilm.xml
+++ b/data/db/compact-fujifilm.xml
@@ -172,6 +172,13 @@
 
     <camera>
         <maker>Fujifilm</maker>
+        <model>X100V</model>
+        <mount>fujix100</mount>
+        <cropfactor>1.534</cropfactor>
+    </camera>
+    
+    <camera>
+        <maker>Fujifilm</maker>
         <model>X10</model>
         <mount>fujix10</mount>
         <cropfactor>3.93</cropfactor>


### PR DESCRIPTION
Crop factor from official sensor specs (23.5mm×15.6mm), consistent with X-Pro3 in mil-fujifilm.xml, which uses the same sensor.