### PR TITLE
Adding EOS R, RP, R5, R6

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -188,6 +188,39 @@
 
     <camera>
         <maker>Canon</maker>
+        <model>Canon EOS R</model>
+        <model lang="en">EOS R</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS RP</model>
+        <model lang="en">EOS RP</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS R5</model>
+        <model lang="en">EOS R5</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS R6</model>
+        <model lang="en">EOS R6</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+
+    <camera>
+        <maker>Canon</maker>
         <model>Canon EOS 1000D</model>
         <model lang="en">EOS 1000D</model>
         <mount>Canon EF-S</mount>


### PR DESCRIPTION
The new EOS R series has a couple of cameras which is not listed in the list of cameras. This PR adds 4 new cameras to the list including the a new mount type RF.