### PR TITLE
Bugfix distortion for Canon EF100-400mm f/4.5-5.6L IS II USM

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -3845,11 +3845,11 @@
         <mount>Canon EF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
-            <distortion model="ptlens" focal="100" a="0,.0029" b="-0,.00471" c="0,.00011"/>
-            <distortion model="ptlens" focal="135" a="-0,.00515" b="0,.02136" c="-0,.02563"/>
-            <distortion model="ptlens" focal="200" a="0,.01053" b="-0,.02855" c="0,.0228"/>
-            <distortion model="ptlens" focal="300" a="0,.00312" b="-0,.00066" c="-0,.00909"/>
-            <distortion model="ptlens" focal="400" a="0,.00784" b="-0,.01309" c="0,.00276"/>
+            <distortion model="ptlens" focal="100" a="-0.00104" b="-0.00264" c="-0.00045"/>
+            <distortion model="ptlens" focal="135" a="-0.0049" b="0.0167" c="-0.02249"/>
+            <distortion model="ptlens" focal="200" a="0.00118" b="-0.00395" c="0.00649"/>
+            <distortion model="ptlens" focal="300" a="-0.0007" b="0.00406" c="-0.00001"/>
+            <distortion model="ptlens" focal="400" a="-0.00355" b="0.01547" c="-0.00989"/>
             <tca model="poly3" focal="100" vr="1.0000577" vb="1.0001939"/>
             <tca model="poly3" focal="135" vr="1.0000274" vb="1.0001208"/>
             <tca model="poly3" focal="200" vr="0.9999920" vb="1.0000585"/>


### PR DESCRIPTION
did a new measure for distortion since the correction didn't work due to typos.
So here the new results ... (also checked for typo) 
sorry for the noise...