### PR TITLE
Remove duplicate cameras (EOS R, EOS RP, EOS R5, EOS R6)

### DIFF
--- a/data/db/mil-samyang.xml
+++ b/data/db/mil-samyang.xml
@@ -175,6 +175,32 @@
             <tca model="poly3" focal="45" vr="1.0000542" vb="0.9998050"/>
             <tca model="poly3" focal="45" vr="1.0000571" vb="0.9997949"/>
             <tca model="poly3" focal="45" vr="1.0000591" vb="0.9998019"/>
+            <vignetting model="pa" focal="45" aperture="1.8" distance="10" k1="-1.6692" k2="1.7384" k3="-0.7699"/>
+            <vignetting model="pa" focal="45" aperture="1.8" distance="1000" k1="-1.6692" k2="1.7384" k3="-0.7699"/>
+            <vignetting model="pa" focal="45" aperture="2" distance="10" k1="-1.0363" k2="0.4369" k3="-0.0449"/>
+            <vignetting model="pa" focal="45" aperture="2" distance="1000" k1="-1.0363" k2="0.4369" k3="-0.0449"/>
+            <vignetting model="pa" focal="45" aperture="2.2" distance="10" k1="-0.4480" k2="-0.3993" k3="0.3087"/>
+            <vignetting model="pa" focal="45" aperture="2.2" distance="1000" k1="-0.4480" k2="-0.3993" k3="0.3087"/>
+            <vignetting model="pa" focal="45" aperture="2.5" distance="10" k1="-0.5832" k2="0.0773" k3="0.0045"/>
+            <vignetting model="pa" focal="45" aperture="2.5" distance="1000" k1="-0.5832" k2="0.0773" k3="0.0045"/>
+            <vignetting model="pa" focal="45" aperture="2.8" distance="10" k1="-0.9296" k2="0.7392" k3="-0.3177"/>
+            <vignetting model="pa" focal="45" aperture="2.8" distance="1000" k1="-0.9296" k2="0.7392" k3="-0.3177"/>
+            <vignetting model="pa" focal="45" aperture="3.2" distance="10" k1="-0.8646" k2="0.5598" k3="-0.1937"/>
+            <vignetting model="pa" focal="45" aperture="3.2" distance="1000" k1="-0.8646" k2="0.5598" k3="-0.1937"/>
+            <vignetting model="pa" focal="45" aperture="3.5" distance="10" k1="-0.8576" k2="0.4767" k3="-0.1440"/>
+            <vignetting model="pa" focal="45" aperture="3.5" distance="1000" k1="-0.8576" k2="0.4767" k3="-0.1440"/>
+            <vignetting model="pa" focal="45" aperture="4" distance="10" k1="-0.8519" k2="0.4042" k3="-0.0928"/>
+            <vignetting model="pa" focal="45" aperture="4" distance="1000" k1="-0.8519" k2="0.4042" k3="-0.0928"/>
+            <vignetting model="pa" focal="45" aperture="4.5" distance="10" k1="-0.8383" k2="0.3965" k3="-0.0991"/>
+            <vignetting model="pa" focal="45" aperture="4.5" distance="1000" k1="-0.8383" k2="0.3965" k3="-0.0991"/>
+            <vignetting model="pa" focal="45" aperture="5" distance="10" k1="-0.8187" k2="0.3477" k3="-0.0786"/>
+            <vignetting model="pa" focal="45" aperture="5" distance="1000" k1="-0.8187" k2="0.3477" k3="-0.0786"/>
+            <vignetting model="pa" focal="45" aperture="5.6" distance="10" k1="-0.8097" k2="0.3420" k3="-0.0843"/>
+            <vignetting model="pa" focal="45" aperture="5.6" distance="1000" k1="-0.8097" k2="0.3420" k3="-0.0843"/>
+            <vignetting model="pa" focal="45" aperture="6.3" distance="10" k1="-0.7996" k2="0.3189" k3="-0.0678"/>
+            <vignetting model="pa" focal="45" aperture="6.3" distance="1000" k1="-0.7996" k2="0.3189" k3="-0.0678"/>
+            <vignetting model="pa" focal="45" aperture="22" distance="10" k1="-0.8160" k2="0.2762" k3="-0.0272"/>
+            <vignetting model="pa" focal="45" aperture="22" distance="1000" k1="-0.8160" k2="0.2762" k3="-0.0272"/>
         </calibration>
     </lens>
 

--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -231,6 +231,14 @@
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
     </camera>
+    
+    <camera>
+        <maker>Sony</maker>
+        <model>ILCE-1</model>
+        <model lang="en">Alpha 1</model>
+        <mount>Sony E</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
 
     <lens>
         <maker>Sony</maker>

--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -3838,7 +3838,100 @@
             <vignetting model="pa" focal="400" aperture="40" distance="1000" k1="-0.1404" k2="-0.0142" k3="0.0530"/>
         </calibration>
     </lens>
-
+    
+    <lens>
+        <maker>Canon</maker>
+        <model>Canon EF 100-400mm f/4.5-5.6L IS II USM</model>
+        <mount>Canon EF</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="100" a="0,.0029" b="-0,.00471" c="0,.00011"/>
+            <distortion model="ptlens" focal="135" a="-0,.00515" b="0,.02136" c="-0,.02563"/>
+            <distortion model="ptlens" focal="200" a="0,.01053" b="-0,.02855" c="0,.0228"/>
+            <distortion model="ptlens" focal="300" a="0,.00312" b="-0,.00066" c="-0,.00909"/>
+            <distortion model="ptlens" focal="400" a="0,.00784" b="-0,.01309" c="0,.00276"/>
+            <tca model="poly3" focal="100" vr="1.0000577" vb="1.0001939"/>
+            <tca model="poly3" focal="135" vr="1.0000274" vb="1.0001208"/>
+            <tca model="poly3" focal="200" vr="0.9999920" vb="1.0000585"/>
+            <tca model="poly3" focal="300" vr="0.9999717" vb="1.0000282"/>
+            <tca model="poly3" focal="400" vr="0.9999391" vb="1.0000137"/>
+            <vignetting model="pa" focal="100" aperture="4.5" distance="10" k1="-0.5317" k2="0.5776" k3="-0.3664"/>
+            <vignetting model="pa" focal="100" aperture="4.5" distance="1000" k1="-0.5317" k2="0.5776" k3="-0.3664"/>
+            <vignetting model="pa" focal="100" aperture="5.6" distance="10" k1="-0.0722" k2="-0.1684" k3="0.0856"/>
+            <vignetting model="pa" focal="100" aperture="5.6" distance="1000" k1="-0.0722" k2="-0.1684" k3="0.0856"/>
+            <vignetting model="pa" focal="100" aperture="8" distance="10" k1="-0.0761" k2="0.1610" k3="-0.0549"/>
+            <vignetting model="pa" focal="100" aperture="8" distance="1000" k1="-0.0761" k2="0.1610" k3="-0.0549"/>
+            <vignetting model="pa" focal="100" aperture="11" distance="10" k1="-0.0852" k2="0.1859" k3="-0.0727"/>
+            <vignetting model="pa" focal="100" aperture="11" distance="1000" k1="-0.0852" k2="0.1859" k3="-0.0727"/>
+            <vignetting model="pa" focal="100" aperture="16" distance="10" k1="-0.0933" k2="0.2109" k3="-0.0895"/>
+            <vignetting model="pa" focal="100" aperture="16" distance="1000" k1="-0.0933" k2="0.2109" k3="-0.0895"/>
+            <vignetting model="pa" focal="100" aperture="22" distance="10" k1="-0.0867" k2="0.1789" k3="-0.0637"/>
+            <vignetting model="pa" focal="100" aperture="22" distance="1000" k1="-0.0867" k2="0.1789" k3="-0.0637"/>
+            <vignetting model="pa" focal="100" aperture="32" distance="10" k1="-0.0870" k2="0.1814" k3="-0.0657"/>
+            <vignetting model="pa" focal="100" aperture="32" distance="1000" k1="-0.0870" k2="0.1814" k3="-0.0657"/>
+            <vignetting model="pa" focal="135" aperture="5" distance="10" k1="-0.4238" k2="0.0814" k3="-0.0255"/>
+            <vignetting model="pa" focal="135" aperture="5" distance="1000" k1="-0.4238" k2="0.0814" k3="-0.0255"/>
+            <vignetting model="pa" focal="135" aperture="5.6" distance="10" k1="-0.0894" k2="-0.3342" k3="0.1694"/>
+            <vignetting model="pa" focal="135" aperture="5.6" distance="1000" k1="-0.0894" k2="-0.3342" k3="0.1694"/>
+            <vignetting model="pa" focal="135" aperture="8" distance="10" k1="-0.0684" k2="-0.0132" k3="0.0366"/>
+            <vignetting model="pa" focal="135" aperture="8" distance="1000" k1="-0.0684" k2="-0.0132" k3="0.0366"/>
+            <vignetting model="pa" focal="135" aperture="11" distance="10" k1="-0.0697" k2="-0.0032" k3="0.0280"/>
+            <vignetting model="pa" focal="135" aperture="11" distance="1000" k1="-0.0697" k2="-0.0032" k3="0.0280"/>
+            <vignetting model="pa" focal="135" aperture="16" distance="10" k1="-0.0687" k2="-0.0032" k3="0.0253"/>
+            <vignetting model="pa" focal="135" aperture="16" distance="1000" k1="-0.0687" k2="-0.0032" k3="0.0253"/>
+            <vignetting model="pa" focal="135" aperture="22" distance="10" k1="-0.0713" k2="0.0012" k3="0.0244"/>
+            <vignetting model="pa" focal="135" aperture="22" distance="1000" k1="-0.0713" k2="0.0012" k3="0.0244"/>
+            <vignetting model="pa" focal="135" aperture="32" distance="10" k1="-0.0598" k2="-0.0316" k3="0.0472"/>
+            <vignetting model="pa" focal="135" aperture="32" distance="1000" k1="-0.0598" k2="-0.0316" k3="0.0472"/>
+            <vignetting model="pa" focal="200" aperture="5" distance="10" k1="-0.4423" k2="-0.0793" k3="0.0938"/>
+            <vignetting model="pa" focal="200" aperture="5" distance="1000" k1="-0.4423" k2="-0.0793" k3="0.0938"/>
+            <vignetting model="pa" focal="200" aperture="5.6" distance="10" k1="0.0269" k2="-0.7742" k3="0.3792"/>
+            <vignetting model="pa" focal="200" aperture="5.6" distance="1000" k1="0.0269" k2="-0.7742" k3="0.3792"/>
+            <vignetting model="pa" focal="200" aperture="8" distance="10" k1="-0.1523" k2="0.2404" k3="-0.1558"/>
+            <vignetting model="pa" focal="200" aperture="8" distance="1000" k1="-0.1523" k2="0.2404" k3="-0.1558"/>
+            <vignetting model="pa" focal="200" aperture="11" distance="10" k1="-0.1181" k2="0.1141" k3="-0.0424"/>
+            <vignetting model="pa" focal="200" aperture="11" distance="1000" k1="-0.1181" k2="0.1141" k3="-0.0424"/>
+            <vignetting model="pa" focal="200" aperture="16" distance="10" k1="-0.1128" k2="0.0962" k3="-0.0307"/>
+            <vignetting model="pa" focal="200" aperture="16" distance="1000" k1="-0.1128" k2="0.0962" k3="-0.0307"/>
+            <vignetting model="pa" focal="200" aperture="22" distance="10" k1="-0.1138" k2="0.0876" k3="-0.0246"/>
+            <vignetting model="pa" focal="200" aperture="22" distance="1000" k1="-0.1138" k2="0.0876" k3="-0.0246"/>
+            <vignetting model="pa" focal="200" aperture="32" distance="10" k1="-0.1122" k2="0.0816" k3="-0.0175"/>
+            <vignetting model="pa" focal="200" aperture="32" distance="1000" k1="-0.1122" k2="0.0816" k3="-0.0175"/>
+            <vignetting model="pa" focal="200" aperture="36" distance="10" k1="-0.0980" k2="0.0412" k3="0.0059"/>
+            <vignetting model="pa" focal="200" aperture="36" distance="1000" k1="-0.0980" k2="0.0412" k3="0.0059"/>
+            <vignetting model="pa" focal="300" aperture="5" distance="10" k1="-0.3212" k2="-0.8003" k3="0.5791"/>
+            <vignetting model="pa" focal="300" aperture="5" distance="1000" k1="-0.3212" k2="-0.8003" k3="0.5791"/>
+            <vignetting model="pa" focal="300" aperture="5.6" distance="10" k1="-0.3104" k2="-0.7014" k3="0.5011"/>
+            <vignetting model="pa" focal="300" aperture="5.6" distance="1000" k1="-0.3104" k2="-0.7014" k3="0.5011"/>
+            <vignetting model="pa" focal="300" aperture="8" distance="10" k1="0.0814" k2="-0.6119" k3="0.2428"/>
+            <vignetting model="pa" focal="300" aperture="8" distance="1000" k1="0.0814" k2="-0.6119" k3="0.2428"/>
+            <vignetting model="pa" focal="300" aperture="11" distance="10" k1="-0.1490" k2="0.2713" k3="-0.2516"/>
+            <vignetting model="pa" focal="300" aperture="11" distance="1000" k1="-0.1490" k2="0.2713" k3="-0.2516"/>
+            <vignetting model="pa" focal="300" aperture="16" distance="10" k1="-0.1043" k2="0.0510" k3="-0.0076"/>
+            <vignetting model="pa" focal="300" aperture="16" distance="1000" k1="-0.1043" k2="0.0510" k3="-0.0076"/>
+            <vignetting model="pa" focal="300" aperture="22" distance="10" k1="-0.1058" k2="0.0494" k3="-0.0056"/>
+            <vignetting model="pa" focal="300" aperture="22" distance="1000" k1="-0.1058" k2="0.0494" k3="-0.0056"/>
+            <vignetting model="pa" focal="300" aperture="32" distance="10" k1="-0.1131" k2="0.0536" k3="-0.0066"/>
+            <vignetting model="pa" focal="300" aperture="32" distance="1000" k1="-0.1131" k2="0.0536" k3="-0.0066"/>
+            <vignetting model="pa" focal="300" aperture="36" distance="10" k1="-0.1104" k2="0.0327" k3="0.0117"/>
+            <vignetting model="pa" focal="300" aperture="36" distance="1000" k1="-0.1104" k2="0.0327" k3="0.0117"/>
+            <vignetting model="pa" focal="400" aperture="5.6" distance="10" k1="-0.4438" k2="-0.5109" k3="0.3846"/>
+            <vignetting model="pa" focal="400" aperture="5.6" distance="1000" k1="-0.4438" k2="-0.5109" k3="0.3846"/>
+            <vignetting model="pa" focal="400" aperture="8" distance="10" k1="-0.0108" k2="-0.8651" k3="0.5329"/>
+            <vignetting model="pa" focal="400" aperture="8" distance="1000" k1="-0.0108" k2="-0.8651" k3="0.5329"/>
+            <vignetting model="pa" focal="400" aperture="11" distance="10" k1="-0.0439" k2="-0.0794" k3="-0.0897"/>
+            <vignetting model="pa" focal="400" aperture="11" distance="1000" k1="-0.0439" k2="-0.0794" k3="-0.0897"/>
+            <vignetting model="pa" focal="400" aperture="16" distance="10" k1="-0.0948" k2="0.0159" k3="0.0036"/>
+            <vignetting model="pa" focal="400" aperture="16" distance="1000" k1="-0.0948" k2="0.0159" k3="0.0036"/>
+            <vignetting model="pa" focal="400" aperture="22" distance="10" k1="-0.0909" k2="-0.0043" k3="0.0231"/>
+            <vignetting model="pa" focal="400" aperture="22" distance="1000" k1="-0.0909" k2="-0.0043" k3="0.0231"/>
+            <vignetting model="pa" focal="400" aperture="32" distance="10" k1="-0.1076" k2="0.0198" k3="0.0116"/>
+            <vignetting model="pa" focal="400" aperture="32" distance="1000" k1="-0.1076" k2="0.0198" k3="0.0116"/>
+            <vignetting model="pa" focal="400" aperture="40" distance="10" k1="-0.1137" k2="0.0161" k3="0.0167"/>
+            <vignetting model="pa" focal="400" aperture="40" distance="1000" k1="-0.1137" k2="0.0161" k3="0.0167"/>
+        </calibration>
+    </lens>
+    
     <lens>
         <maker>Canon</maker>
         <model>Canon EF 100-400mm f/4.5-5.6L IS II USM</model>

--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -3845,11 +3845,11 @@
         <mount>Canon EF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
-            <distortion model="ptlens" focal="100" a="0,.0029" b="-0,.00471" c="0,.00011"/>
-            <distortion model="ptlens" focal="135" a="-0,.00515" b="0,.02136" c="-0,.02563"/>
-            <distortion model="ptlens" focal="200" a="0,.01053" b="-0,.02855" c="0,.0228"/>
-            <distortion model="ptlens" focal="300" a="0,.00312" b="-0,.00066" c="-0,.00909"/>
-            <distortion model="ptlens" focal="400" a="0,.00784" b="-0,.01309" c="0,.00276"/>
+            <distortion model="ptlens" focal="100" a="-0.00104" b="-0.00264" c="-0.00045"/>
+            <distortion model="ptlens" focal="135" a="-0.0049" b="0.0167" c="-0.02249"/>
+            <distortion model="ptlens" focal="200" a="0.00118" b="-0.00395" c="0.00649"/>
+            <distortion model="ptlens" focal="300" a="-0.0007" b="0.00406" c="-0.00001"/>
+            <distortion model="ptlens" focal="400" a="-0.00355" b="0.01547" c="-0.00989"/>
             <tca model="poly3" focal="100" vr="1.0000577" vb="1.0001939"/>
             <tca model="poly3" focal="135" vr="1.0000274" vb="1.0001208"/>
             <tca model="poly3" focal="200" vr="0.9999920" vb="1.0000585"/>

--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -4445,6 +4445,32 @@
         <cropfactor>1</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="135" a="-0.007" b="0.025" c="-0.019"/>
+            <!-- Taken with Canon R5 -->
+            <tca model="poly3" focal="135.0" vr="0.9999877" vb="1.0000394" />
+            <vignetting model="pa" focal="135.0" aperture="2.0" distance="0.9" k1="-0.0093657" k2="-0.5204728" k3="0.2646156" />
+            <vignetting model="pa" focal="135.0" aperture="2.0" distance="1.8" k1="-0.3720239" k2="-0.1212769" k3="0.0723688" />
+            <vignetting model="pa" focal="135.0" aperture="2.0" distance="3.6" k1="-0.5967040" k2="0.1838160" k3="-0.0912153" />
+            <vignetting model="pa" focal="135.0" aperture="2.0" distance="1000" k1="-0.5029396" k2="0.0773026" k3="-0.0396684" />
+            <vignetting model="pa" focal="135.0" aperture="2.8" distance="0.9" k1="-0.0291882" k2="0.0296634" k3="-0.1059211" />
+            <vignetting model="pa" focal="135.0" aperture="2.8" distance="1.8" k1="0.0501388" k2="-0.3758652" k3="0.1281745" />
+            <vignetting model="pa" focal="135.0" aperture="2.8" distance="3.6" k1="0.0760025" k2="-0.3616551" k3="0.1017797" />
+            <vignetting model="pa" focal="135.0" aperture="2.8" distance="1000" k1="0.0543297" k2="-0.5277796" k3="0.2136678" />
+            <vignetting model="pa" focal="135.0" aperture="4.0" distance="0.9" k1="-0.0761320" k2="-0.0088900" k3="0.0021939" />
+            <vignetting model="pa" focal="135.0" aperture="4.0" distance="1.8" k1="-0.0861135" k2="0.1701948" k3="-0.1948492" />
+            <vignetting model="pa" focal="135.0" aperture="4.0" distance="3.6" k1="-0.0479163" k2="0.1642694" k3="-0.2124924" />
+            <vignetting model="pa" focal="135.0" aperture="4.0" distance="1000" k1="-0.0311125" k2="0.0549481" k3="-0.1758831" />
+            <vignetting model="pa" focal="135.0" aperture="5.6" distance="0.9" k1="-0.0793112" k2="-0.0182007" k3="0.0135455" />
+            <vignetting model="pa" focal="135.0" aperture="5.6" distance="1.8" k1="-0.0524171" k2="-0.0019293" k3="-0.0001025" />
+            <vignetting model="pa" focal="135.0" aperture="5.6" distance="3.6" k1="-0.0700950" k2="0.0863139" k3="-0.0754956" />
+            <vignetting model="pa" focal="135.0" aperture="5.6" distance="1000" k1="-0.0991785" k2="0.1866371" k3="-0.1471030" />
+            <vignetting model="pa" focal="135.0" aperture="8.0" distance="0.9" k1="-0.1002591" k2="0.0179194" k3="-0.0068310" />
+            <vignetting model="pa" focal="135.0" aperture="8.0" distance="1.8" k1="-0.0560233" k2="-0.0005941" k3="0.0013101" />
+            <vignetting model="pa" focal="135.0" aperture="8.0" distance="3.6" k1="-0.0555297" k2="0.0024731" k3="0.0025877" />
+            <vignetting model="pa" focal="135.0" aperture="8.0" distance="1000" k1="-0.0196277" k2="-0.0153905" k3="0.0100609" />
+            <vignetting model="pa" focal="135.0" aperture="32.0" distance="0.9" k1="-0.1144479" k2="0.0478949" k3="-0.0327243" />
+            <vignetting model="pa" focal="135.0" aperture="32.0" distance="1.8" k1="-0.0788924" k2="0.0283916" k3="-0.0159735" />
+            <vignetting model="pa" focal="135.0" aperture="32.0" distance="3.6" k1="-0.0659608" k2="0.0090575" k3="0.0034382" />
+            <vignetting model="pa" focal="135.0" aperture="32.0" distance="1000" k1="-0.0489879" k2="-0.0068094" k3="0.0145685" />
         </calibration>
     </lens>
 

--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -188,6 +188,39 @@
 
     <camera>
         <maker>Canon</maker>
+        <model>Canon EOS R</model>
+        <model lang="en">EOS R</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS RP</model>
+        <model lang="en">EOS RP</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS R5</model>
+        <model lang="en">EOS R5</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
+        <model>Canon EOS R6</model>
+        <model lang="en">EOS R6</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+
+    <camera>
+        <maker>Canon</maker>
         <model>Canon EOS 1000D</model>
         <model lang="en">EOS 1000D</model>
         <mount>Canon EF-S</mount>

--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -188,39 +188,6 @@
 
     <camera>
         <maker>Canon</maker>
-        <model>Canon EOS R</model>
-        <model lang="en">EOS R</model>
-        <mount>Canon RF</mount>
-        <cropfactor>1</cropfactor>
-    </camera>
-
-    <camera>
-        <maker>Canon</maker>
-        <model>Canon EOS RP</model>
-        <model lang="en">EOS RP</model>
-        <mount>Canon RF</mount>
-        <cropfactor>1</cropfactor>
-    </camera>
-
-    <camera>
-        <maker>Canon</maker>
-        <model>Canon EOS R5</model>
-        <model lang="en">EOS R5</model>
-        <mount>Canon RF</mount>
-        <cropfactor>1</cropfactor>
-    </camera>
-
-    <camera>
-        <maker>Canon</maker>
-        <model>Canon EOS R6</model>
-        <model lang="en">EOS R6</model>
-        <mount>Canon RF</mount>
-        <cropfactor>1</cropfactor>
-    </camera>
-
-
-    <camera>
-        <maker>Canon</maker>
         <model>Canon EOS 1000D</model>
         <model lang="en">EOS 1000D</model>
         <mount>Canon EF-S</mount>

--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -4671,7 +4671,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>Nikon AF-P DX Nikkor 10-20mm f/4.5-5.6 VR 168</model>
+        <model>Nikon AF-P DX Nikkor 10-20mm f/4.5-5.6G VR 168</model>
         <model lang="en">Nikkor AF-P 10-20mm f/4.5-5.6G DX VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>

--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -860,7 +860,7 @@
 
     <lens>
         <maker>Tamron</maker>
-        <model>Tamron SP 70-300mm f/4.0-5.6 Di VC USD (A005)</model>
+        <model>Tamron SP 70-300mm f/4-5.6 Di VC USD (A005)</model>
         <mount>Canon EF</mount>
         <mount>Nikon F AF</mount>
         <mount>Sony Alpha</mount>

--- a/data/db/slr-tokina.xml
+++ b/data/db/slr-tokina.xml
@@ -256,10 +256,10 @@
     </lens>
     
     <lens>
-        <maker>Tokina </maker>
+        <maker>Tokina</maker>
         <model>Tokina 17mm f/3.5 AT-X 17 AF Pro</model>
         <mount>Canon EF</mount>
-        <cropfactor>1.0</cropfactor>
+        <cropfactor>1</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="17.0" a="0.009" b="-0.001" c="-0.059" />
             <tca model="poly3" focal="17.0" vr="1.0003223" vb="1.0000513" />

--- a/data/db/slr-tokina.xml
+++ b/data/db/slr-tokina.xml
@@ -254,6 +254,37 @@
             <distortion model="ptlens" focal="17" a="0" b="-0.004083" c="-0.015672"/>
         </calibration>
     </lens>
+    
+    <lens>
+        <maker>Tokina </maker>
+        <model>Tokina 17mm f/3.5 AT-X 17 AF Pro</model>
+        <mount>Canon EF</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="17.0" a="0.009" b="-0.001" c="-0.059" />
+            <tca model="poly3" focal="17.0" vr="1.0003223" vb="1.0000513" />
+            <vignetting model="pa" focal="17.0" aperture="3.5" distance="0.25" k1="-0.7709374" k2="-0.2582311" k3="0.3105781" />
+            <vignetting model="pa" focal="17.0" aperture="3.5" distance="0.5" k1="-0.8159654" k2="-0.1581800" k3="0.2417777" />
+            <vignetting model="pa" focal="17.0" aperture="3.5" distance="1.5" k1="-0.7055708" k2="-0.3593165" k3="0.3286411" />
+            <vignetting model="pa" focal="17.0" aperture="3.5" distance="1000" k1="-0.6963268" k2="-0.3397731" k3="0.2918477" />
+            <vignetting model="pa" focal="17.0" aperture="5.0" distance="0.25" k1="-0.8580720" k2="0.2014674" k3="0.0114345" />
+            <vignetting model="pa" focal="17.0" aperture="5.0" distance="0.5" k1="-0.8822321" k2="0.2141567" k3="0.0064476" />
+            <vignetting model="pa" focal="17.0" aperture="5.0" distance="1.5" k1="-0.7981581" k2="0.1503974" k3="-0.0316313" />
+            <vignetting model="pa" focal="17.0" aperture="5.0" distance="1000" k1="-0.7727548" k2="0.1617771" k3="-0.0756839" />
+            <vignetting model="pa" focal="17.0" aperture="7.1" distance="0.25" k1="-0.8365677" k2="0.1085976" k3="0.1027428" />
+            <vignetting model="pa" focal="17.0" aperture="7.1" distance="0.5" k1="-0.8400408" k2="0.0793102" k3="0.1272177" />
+            <vignetting model="pa" focal="17.0" aperture="7.1" distance="1.5" k1="-0.7866398" k2="0.0249410" k3="0.1262969" />
+            <vignetting model="pa" focal="17.0" aperture="7.1" distance="1000" k1="-0.7570918" k2="0.0425956" k3="0.0720863" />
+            <vignetting model="pa" focal="17.0" aperture="10.0" distance="0.25" k1="-0.9154341" k2="0.1943420" k3="0.0820829" />
+            <vignetting model="pa" focal="17.0" aperture="10.0" distance="0.5" k1="-0.8901946" k2="0.1171638" k3="0.1306609" />
+            <vignetting model="pa" focal="17.0" aperture="10.0" distance="1.5" k1="-0.7711105" k2="-0.0316293" k3="0.1750651" />
+            <vignetting model="pa" focal="17.0" aperture="10.0" distance="1000" k1="-0.7519757" k2="-0.0670322" k3="0.1925755" />
+            <vignetting model="pa" focal="17.0" aperture="22.0" distance="0.25" k1="-0.9378107" k2="0.1811523" k3="0.1143115" />
+            <vignetting model="pa" focal="17.0" aperture="22.0" distance="0.5" k1="-0.8634166" k2="0.0765945" k3="0.1469881" />
+            <vignetting model="pa" focal="17.0" aperture="22.0" distance="1.5" k1="-0.7647955" k2="-0.0457266" k3="0.1861739" />
+            <vignetting model="pa" focal="17.0" aperture="22.0" distance="1000" k1="-0.8201483" k2="0.0254092" k3="0.1602543" />
+        </calibration>
+    </lens>
 
     <lens>
         <maker>Tokina</maker>


### PR DESCRIPTION
Canon EOS R
Canon EOS RP
Canon EOS R5
Canon EOS R6

The cameras are now moved
from: mil-canon.xml
to: slr-canon.xml