### PR TITLE
Use official Canon RF lens model names

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -584,7 +584,7 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>RF24-105mm F4 L IS USM</model>
+        <model>Canon RF 24-105mm F4L IS USM</model>
         <mount>Canon RF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -692,7 +692,7 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>RF70-200mm F2.8 L IS USM</model>
+        <model>Canon RF 70-200mm F2.8L IS USM</model>
         <mount>Canon RF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -709,7 +709,7 @@
     
     <lens>
         <maker>Canon</maker>
-        <model>Canon RF85mm F1.2L USM</model>
+        <model>Canon RF 85mm F1.2L USM</model>
         <mount>Canon RF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -740,7 +740,7 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>RF85mm F2 MACRO IS STM</model>
+        <model>Canon RF 85mm F2 MACRO IS STM</model>
         <mount>Canon RF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>


### PR DESCRIPTION
These are the official lens names for Canon RF.
exiftool already uses these names and a patch for exiv2 is prepared.