### PR TITLE
Correct Olympus TG-[1-6] camera names

### DIFF
--- a/data/db/compact-olympus.xml
+++ b/data/db/compact-olympus.xml
@@ -254,8 +254,8 @@
         <maker>Olympus Corporation</maker>
         <maker lang="en">Olympus</maker>
         <model>TG-1</model>
-        <model lang="en">Stylus TG-1</model>
-        <mount>olympusStylusTG4</mount>
+        <model lang="en">Tough TG-1</model>
+        <mount>olympusToughTG4</mount>
         <cropfactor>5.56</cropfactor>
     </camera>
 
@@ -263,8 +263,8 @@
         <maker>Olympus Corporation</maker>
         <maker lang="en">Olympus</maker>
         <model>TG-2</model>
-        <model lang="en">Stylus TG-2</model>
-        <mount>olympusStylusTG4</mount>
+        <model lang="en">Tough TG-2</model>
+        <mount>olympusToughTG4</mount>
         <cropfactor>5.56</cropfactor>
     </camera>
 
@@ -272,8 +272,8 @@
         <maker>Olympus Corporation</maker>
         <maker lang="en">Olympus</maker>
         <model>TG-3</model>
-        <model lang="en">Stylus TG-3</model>
-        <mount>olympusStylusTG4</mount>
+        <model lang="en">Tough TG-3</model>
+        <mount>olympusToughTG4</mount>
         <cropfactor>5.56</cropfactor>
     </camera>
 
@@ -281,8 +281,8 @@
         <maker>Olympus Corporation</maker>
         <maker lang="en">Olympus</maker>
         <model>TG-4</model>
-        <model lang="en">Stylus TG-4</model>
-        <mount>olympusStylusTG4</mount>
+        <model lang="en">Tough TG-4</model>
+        <mount>olympusToughTG4</mount>
         <cropfactor>5.56</cropfactor>
     </camera>
 
@@ -299,8 +299,8 @@
         <maker>Olympus Corporation</maker>
         <maker lang="en">Olympus</maker>
         <model>TG-6</model>
-        <model lang="en">Stylus TG-6</model>
-        <mount>olympusStylusTG4</mount>
+        <model lang="en">Tough TG-6</model>
+        <mount>olympusToughTG4</mount>
         <cropfactor>5.56</cropfactor>
     </camera>
 
@@ -672,14 +672,14 @@
 
     <lens>
         <maker>Olympus</maker>
-        <model>Olympus Stylus TG-4 &amp; compatibles</model>
+        <model>Olympus Tough TG-4 &amp; compatibles</model>
         <model lang="en">fixed lens</model>
         <model lang="de">festes Objektiv</model>
-        <mount>olympusStylusTG4</mount>
+        <mount>olympusToughTG4</mount>
         <cropfactor>5.56</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
-            <!-- Taken with Olympus Stylus TG-4 -->
+            <!-- Taken with Olympus Tough TG-4 -->
             <distortion model="poly3" focal="4.5" k1="-0.04661"/>
             <distortion model="poly3" focal="5.1" k1="-0.03028"/>
             <distortion model="poly3" focal="6.9" k1="-0.00581"/>


### PR DESCRIPTION
Olympus TG-[1-6] cameras are Tough, not Stylus. Correcting model and mount names.