### PR TITLE
Fix name of Tamron 17-35mm

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -78,8 +78,7 @@
 
     <lens>
         <maker>Tamron</maker>
-        <model>17-35mm F/2.8-4 Di OSD</model>
-        <!-- The 'LensIDNumber' EXIF tag = 203 - use with old versions of exiv2 -->
+        <model>Tamron 17-35mm F/2.8-4 Di OSD</model>
         <mount>Canon EF</mount>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>


### PR DESCRIPTION
When selecting this in e.g. darktable it includes the maker name. Also, it is consistent with the other Tamron names in this file.