### PR TITLE
Add Pentax KAF mount to Samyang 16mm f/2.0 ED AS UMC CS lens

### DIFF
--- a/data/db/slr-samyang.xml
+++ b/data/db/slr-samyang.xml
@@ -109,6 +109,7 @@
         <mount>Micro 4/3 System</mount>
         <mount>Samsung NX</mount>
         <mount>Canon EF-M</mount>
+        <mount>Pentax KAF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
             <!-- taken with Nikon D5500 -->


### PR DESCRIPTION
Fixes #1552