### PR TITLE
Fix model names and descriptions for Olympus M.Zuiko Digital ED 40-150mm f/2.8 PRO (#1544)

### DIFF
--- a/data/db/mil-olympus.xml
+++ b/data/db/mil-olympus.xml
@@ -1361,7 +1361,8 @@
 
     <lens>
         <maker>Olympus</maker>
-        <model>Olympus M.Zuiko Digital ED 40-150mm f/2.8 Pro</model>
+	<model>OLYMPUS M.40-150mm F2.8</model>
+	<model lang="en">Olympus M.Zuiko ED 40-150mm F2.8 PRO</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1378,9 +1379,8 @@
 
     <lens>
         <maker>Olympus</maker>
-        <model>Olympus M.Zuiko Digital ED 40-150mm f/2.8 Pro + 1.4x converter</model>
-        <model lang="en">Olympus M.Zuiko Digital ED 40-150mm f/2.8 Pro + 1.4× conv.</model>
-        <model lang="de">Olympus M.Zuiko Digital ED 40-150mm f/2.8 Pro + 1.4×-Konv.</model>
+        <model>M.40-150mm F2.8 + MC-14</model>
+        <model lang="en">Olympus M.Zuiko Digital ED 40-150mm f/2.8 PRO + 1.4× conv.</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>


### PR DESCRIPTION
Also fixes the entry for the lens when attached to a MC-14 teleconverter.

Fixes #1544