### PR TITLE
Nikon camera/lens database maintenance (#1353, #1371, others)

### DIFF
--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -331,7 +331,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>Nikkor Z 24-70mm f/4 S</model>
+        <model>NIKKOR Z 24-70mm f/4 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>

--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -483,25 +483,25 @@
     </lens>
 	
     <lens>
-    <maker>Nikon</maker>
-    <model>NIKKOR Z 24-200mm f/4-6.3 VR</model>
-    <mount>Nikon Z</mount>
-    <cropfactor>1</cropfactor>
-    <calibration>
-        <distortion model="ptlens" focal="24" a="0.029427303584772774" b="-0.10372635871864969" c="0.04007366049378727"/>
-        <distortion model="ptlens" focal="38" a="0.010039276890734349" b="-0.019018579758017618" c="0.012124283612537735"/>
-        <distortion model="ptlens" focal="52" a="0.009269921825384317" b="-0.012043929971475851" c="0.022274437294479553"/>
-        <distortion model="ptlens" focal="94" a="-0.001508449372620077" b="0.02879419057228741" c="-0.02366348197099592"/>
-        <distortion model="ptlens" focal="140" a="-0.0012467131640865495" b="0.021459850448953443" c="-0.011450469560964946"/>
-        <distortion model="ptlens" focal="200" a="7.132598710890537e-05" b="0.01340609626856572" c="0.0011983453411721758"/>
-        <tca model="poly3" focal="24" vr="1.0003084" vb="1.0002809"/>
-        <tca model="poly3" focal="44" vr="1.0001410" vb="1.0000968"/>
-        <tca model="poly3" focal="64" vr="1.0000703" vb="1.0000559"/>
-        <tca model="poly3" focal="91" vr="0.9999584" vb="1.0000168"/>
-        <tca model="poly3" focal="135" vr="0.9998716" vb="0.9999761"/>
-        <tca model="poly3" focal="200" vr="0.9996803" vb="0.9998675"/>
-    </calibration>
-</lens>
+        <maker>Nikon</maker>
+        <model>NIKKOR Z 24-200mm f/4-6.3 VR</model>
+        <mount>Nikon Z</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <distortion model="ptlens" focal="24" a="0.029427303584772774" b="-0.10372635871864969" c="0.04007366049378727"/>
+            <distortion model="ptlens" focal="38" a="0.010039276890734349" b="-0.019018579758017618" c="0.012124283612537735"/>
+            <distortion model="ptlens" focal="52" a="0.009269921825384317" b="-0.012043929971475851" c="0.022274437294479553"/>
+            <distortion model="ptlens" focal="94" a="-0.001508449372620077" b="0.02879419057228741" c="-0.02366348197099592"/>
+            <distortion model="ptlens" focal="140" a="-0.0012467131640865495" b="0.021459850448953443" c="-0.011450469560964946"/>
+            <distortion model="ptlens" focal="200" a="7.132598710890537e-05" b="0.01340609626856572" c="0.0011983453411721758"/>
+            <tca model="poly3" focal="24" vr="1.0003084" vb="1.0002809"/>
+            <tca model="poly3" focal="44" vr="1.0001410" vb="1.0000968"/>
+            <tca model="poly3" focal="64" vr="1.0000703" vb="1.0000559"/>
+            <tca model="poly3" focal="91" vr="0.9999584" vb="1.0000168"/>
+            <tca model="poly3" focal="135" vr="0.9998716" vb="0.9999761"/>
+            <tca model="poly3" focal="200" vr="0.9996803" vb="0.9998675"/>
+        </calibration>
+    </lens>
 
     <lens>
         <maker>Nikon</maker>

--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -129,8 +129,8 @@
     <camera>
         <maker>Nikon Corporation</maker>
         <maker lang="en">Nikon</maker>
-        <model>Nikon Z6</model>
-        <model lang="en">Z6</model>
+        <model>Nikon Z 5</model>
+        <model lang="en">Z 5</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
     </camera>
@@ -138,8 +138,44 @@
     <camera>
         <maker>Nikon Corporation</maker>
         <maker lang="en">Nikon</maker>
-        <model>Nikon Z7</model>
-        <model lang="en">Z7</model>
+        <model>Nikon Z6</model>
+        <model lang="en">Z 6</model>
+        <mount>Nikon Z</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Nikon Corporation</maker>
+        <maker lang="en">Nikon</maker>
+        <model>Nikon Z 6_2</model>
+        <model lang="en">Z 6II</model>
+        <mount>Nikon Z</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Nikon Corporation</maker>
+        <maker lang="en">Nikon</maker>
+        <model>Z7</model>
+        <model lang="en">Z 7</model>
+        <mount>Nikon Z</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Nikon Corporation</maker>
+        <maker lang="en">Nikon</maker>
+        <model>Nikon Z 7_2</model>
+        <model lang="en">Z 7II</model>
+        <mount>Nikon Z</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Nikon Corporation</maker>
+        <maker lang="en">Nikon</maker>
+        <model>Nikon Z 9</model>
+        <model lang="en">Z 9</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
     </camera>
@@ -156,10 +192,10 @@
     <camera>
         <maker>Nikon Corporation</maker>
         <maker lang="en">Nikon</maker>
-        <model>Nikon Z 5</model>
-        <model lang="en">Z 5</model>
+        <model>Nikon Z fc</model>
+        <model lang="en">Z fc</model>
         <mount>Nikon Z</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.531</cropfactor>
     </camera>
 
     <lens>
@@ -490,5 +526,4 @@
             <tca model="poly3" focal="50.0" vr="1.0000005" vb="1.0000475" />
         </calibration>
     </lens>
-
 </lensdatabase>

--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -645,7 +645,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S DX Nikkor 16-80mm f/2.8-4E ED VR</model>
-        <model lang="en">Nikkor AF-S 16-80mm f/2.8-4E DX ED VR</model>
+        <model lang="en">NIKKOR AF-S 16-80mm f/2.8-4E DX ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
@@ -806,7 +806,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S DX Zoom-Nikkor 16-85mm f/3.5-5.6G ED VR</model>
-        <model lang="en">Nikkor AF-S 16-85mm f/3.5-5.6G DX ED VR</model>
+        <model lang="en">NIKKOR AF-S 16-85mm f/3.5-5.6G DX ED VR</model>
         <mount>Nikon F AF</mount>
         <!-- Average crop factor of Nikon APS-C cameras -->
         <cropfactor>1.528</cropfactor>
@@ -1016,7 +1016,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S DX VR Nikkor 18-55mm f/3.5-5.6G II</model>
-        <model lang="en">Nikkor AF-S 18-55mm f/3.5-5.6G DX VR II</model>
+        <model lang="en">NIKKOR AF-S 18-55mm f/3.5-5.6G DX VR II</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.523</cropfactor>
         <calibration>
@@ -1572,7 +1572,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 24-120mm f/4G ED VR 170</model>
-        <model lang="en">Nikkor AF-S 24-120mm f/4G ED VR</model>
+        <model lang="en">NIKKOR AF-S 24-120mm f/4G ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -2211,7 +2211,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 20mm f/1.8G ED</model>
-        <model lang="en">Nikkor AF-S 20mm f/1.8G ED</model>
+        <model lang="en">NIKKOR AF-S 20mm f/1.8G ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -2380,7 +2380,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 28mm f/1.8G</model>
-        <model lang="en">Nikkor AF-S 28mm f/1.8G</model>
+        <model lang="en">NIKKOR AF-S 28mm f/1.8G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -2430,7 +2430,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S DX Nikkor 35mm f/1.8G</model>
-        <model lang="en">Nikkor AF-S 35mm f/1.8G DX</model>
+        <model lang="en">NIKKOR AF-S 35mm f/1.8G DX</model>
         <mount>Nikon F AF</mount>
         <!-- Average crop factor of Nikon APS-C cameras -->
         <cropfactor>1.528</cropfactor>
@@ -2676,7 +2676,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF Nikkor 105mm f/2.8D</model>
-        <model lang="en">Nikkor AF 105mm f/2.8D</model>
+        <model lang="en">Nikkor AF 105mm Micro f/2.8D</model>
         <mount>Nikon F AF</mount>
         <!-- Average crop factor of Nikon APS-C cameras -->
         <cropfactor>1.528</cropfactor>
@@ -2688,7 +2688,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S VR Micro-Nikkor 105mm f/2.8G IF-ED 138</model>
-        <model lang="en">Nikkor AF-S VR 105mm f/2.8G IF-ED</model>
+        <model lang="en">Nikkor AF-S VR 105mm f/2.8G Micro IF-ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -2761,7 +2761,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 85mm f/1.8G 179</model>
-        <model lang="en">Nikkor AF-S 85mm f/1.8G</model>
+        <model lang="en">NIKKOR AF-S 85mm f/1.8G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3012,7 +3012,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S VR Zoom-Nikkor 70-200mm f/4G IF-ED</model>
-        <model lang="en">Nikkor AF-S 70-200mm f/4G VR IF-ED</model>
+        <model lang="en">NIKKOR AF-S 70-200mm f/4G IF-ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3052,7 +3052,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 50mm f/1.8G 176</model>
-        <model lang="en">Nikkor AF-S 50mm f/1.8G</model>
+        <model lang="en">NIKKOR AF-S 50mm f/1.8G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.523</cropfactor>
         <calibration>
@@ -3065,7 +3065,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 50mm f/1.8G</model>
-        <model lang="en">Nikkor AF-S 50mm f/1.8G</model>
+        <model lang="en">NIKKOR AF-S 50mm f/1.8G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3287,7 +3287,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 50mm f/1.4G 160</model>
-        <model lang="en">Nikkor AF-S 50mm f/1.4G</model>
+        <model lang="en">NIKKOR AF-S 50mm f/1.4G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
@@ -3299,7 +3299,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 50mm f/1.4G</model>
-        <model lang="en">Nikkor AF-S 50mm f/1.4G</model>
+        <model lang="en">NIKKOR AF-S 50mm f/1.4G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3442,7 +3442,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 600mm f/4G ED VR</model>
-        <model lang="en">Nikkor AF-S 600mm f/4G ED VR</model>
+        <model lang="en">NIKKOR AF-S 600mm f/4G ED VR</model>
         <mount>Nikon F AF</mount>
         <aperture min="4" max="22"/>
         <cropfactor>1</cropfactor>
@@ -3710,7 +3710,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 85mm f/1.4G</model>
-        <model lang="en">Nikkor AF-S 85mm f/1.4G</model>
+        <model lang="en">NIKKOR AF-S 85mm f/1.4G</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3827,7 +3827,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 300mm f/4E PF ED VR</model>
-        <model lang="en">Nikkor AF-S 300mm f/4E PF ED VR</model>
+        <model lang="en">NIKKOR AF-S 300mm f/4E PF ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3850,7 +3850,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S DX Nikkor 18-300mm f/3.5-5.6G ED VR</model>
-        <model lang="en">Nikkor AF-S 18-300mm f/3.5-5.6G DX ED VR</model>
+        <model lang="en">NIKKOR AF-S 18-300mm f/3.5-5.6G DX ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
@@ -3873,7 +3873,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 35mm f/1.8G ED</model>
-        <model lang="en">Nikkor AF-S 35mm f/1.8G ED</model>
+        <model lang="en">NIKKOR AF-S 35mm f/1.8G ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -3912,7 +3912,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-P DX Nikkor 18-55mm f/3.5-5.6G VR</model>
-        <model lang="en">Nikkor AF-P 18-55mm f/3.5-5.6G DX VR</model>
+        <model lang="en">NIKKOR AF-P 18-55mm f/3.5-5.6G DX VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.523</cropfactor>
         <calibration>
@@ -4002,7 +4002,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 70-200mm f/2.8G ED VR II 162</model>
-        <model lang="en">Nikkor AF-S 70-200mm f/2.8G ED VR II</model>
+        <model lang="en">NIKKOR AF-S 70-200mm f/2.8G ED VR II</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4210,7 +4210,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-P DX Nikkor 70-300mm f/4.5-6.3G ED VR</model>
-        <model lang="en">Nikkor AF-P 70-300mm f/4.5-6.3G DX ED VR</model>
+        <model lang="en">NIKKOR AF-P 70-300mm f/4.5-6.3G DX ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
@@ -4284,7 +4284,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>AF-P Nikkor 70-300mm f/4.5-5.6E ED VR</model>
-        <model lang="en">Nikkor AF-P 70-300mm f/4.5-5.6E ED VR</model>
+        <model lang="en">NIKKOR AF-P 70-300mm f/4.5-5.6E ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4599,7 +4599,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 70-200mm f/2.8E FL ED VR 164</model>
-        <model lang="en">Nikkor AF-S 70-200mm f/2.8E FL ED VR</model>
+        <model lang="en">NIKKOR AF-S 70-200mm f/2.8E FL ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4622,7 +4622,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 300mm f/4D IF-ED</model>
-        <model lang="en">Nikkor AF-S 300mm f/4D IF-ED</model>
+        <model lang="en">NIKKOR AF-S 300mm f/4D IF-ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4645,7 +4645,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF Nikkor 300mm f/4 IF-ED</model>
-        <model lang="en">Nikkor AF 300mm f/4 IF-ED</model>
+        <model lang="en">NIKKOR AF 300mm f/4 IF-ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4670,7 +4670,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 24-70mm f/2.8E ED VR 170</model>
-        <model lang="en">Nikkor AF-S 24-70mm f/2.8E ED VR</model>
+        <model lang="en">NIKKOR AF-S 24-70mm f/2.8E ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4713,7 +4713,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>200-500mm F5.6 174</model>
-        <model lang="en">Nikkor AF-S 200-500mm f/5.6E ED VR</model>
+        <model lang="en">NIKKOR AF-S 200-500mm f/5.6E ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
@@ -4732,7 +4732,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 200-500mm f/5.6E ED VR</model>
-        <model lang="en">Nikkor AF-S 200-500mm f/5.6E ED VR</model>
+        <model lang="en">NIKKOR AF-S 200-500mm f/5.6E ED VR</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -4939,7 +4939,7 @@
     <lens>
         <maker>Nikon</maker>
         <model>Nikon AF-S Nikkor 24mm f/1.8G ED</model>
-        <model lang="en">Nikkor AF-S 24mm f/1.8G ED</model>
+        <model lang="en">NIKKOR AF-S 24mm f/1.8G ED</model>
         <mount>Nikon F AF</mount>
         <cropfactor>1.001</cropfactor>
         <calibration>


### PR DESCRIPTION
- Add the Nikon Z 9, Z 7II, Z 6II and Z fc cameras to the database

- Bring the Nikkor/NIKKOR naming more in line with Nikon's own lists

- Fix wrong indentation in data/db/mil-nikon.xml

Verified against publicly available RAW images from https://www.imaging-resource.com/

Fixes #1353 and #1371
Obsoletes lensfun/pull/1483