### PR TITLE
 Add Lumix DC-FZ1000 II camera, same lens as FZ-1000, update compact-panasonic.xml

### DIFF
--- a/data/db/compact-panasonic.xml
+++ b/data/db/compact-panasonic.xml
@@ -306,6 +306,14 @@
 
     <camera>
         <maker>Panasonic</maker>
+        <model>DC-FZ10002</model>
+        <!-- Same lens as FZ1000 -->
+        <mount>panasonicFZ1000</mount>
+        <cropfactor>2.73</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Panasonic</maker>
         <model>DMC-FZ150</model>
         <mount>panasonicFZ150</mount>
         <cropfactor>5.56</cropfactor>


### PR DESCRIPTION
Add Panasonic Lumix DC-FZ1000 II. Same lens as its predecessor DC-FZ1000.