### PR TITLE
change model name from Tamron 17-35mm f/2.8-4 Di OSD (A037)

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -78,7 +78,7 @@
 
     <lens>
         <maker>Tamron</maker>
-        <model>Tamron 17-35mm F/2.8-4 Di OSD</model>
+        <model>Tamron 17-35mm f/2.8-4 Di OSD (A037)</model>
         <mount>Canon EF</mount>
         <mount>Nikon F AF</mount>
         <cropfactor>1</cropfactor>


### PR DESCRIPTION
No automatic detection with pictures from upload 82f828 (Canon EOS R6). Checked new model name with Canon and Nikon pictures in darktable. Fixes Tamron part of  #1709