### PR TITLE
Fix mount for 4 Canon EF lenses

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -2131,7 +2131,7 @@
         <maker>Canon</maker>
         <model>EF35mm f/1.4L II USM (750)</model>
         <model lang="en">Canon EF 35mm f/1.4L II USM</model>
-        <mount>Canon EF-S</mount>
+        <mount>Canon EF</mount>
         <cropfactor>1.605</cropfactor>
         <calibration>
             <!-- Taken with Canon EOS 7D Mark II -->
@@ -5473,7 +5473,7 @@
     <lens>
         <maker>Canon</maker>
         <model>Canon EF 70-300mm f/4-5.6L IS USM</model>
-        <mount>Canon EF-S</mount>
+        <mount>Canon EF</mount>
         <cropfactor>1.605</cropfactor>
         <calibration>
             <!-- Taken with Canon EOS 7D Mark II -->
@@ -6806,7 +6806,7 @@
     <lens>
         <maker>Canon</maker>
         <model>Canon EF 24mm f/2.8 IS USM</model>
-        <mount>Canon EF-S</mount>
+        <mount>Canon EF</mount>
         <cropfactor>1.613</cropfactor>
         <calibration>
             <!-- Taken with Canon EOS 100D -->
@@ -6906,7 +6906,7 @@
     <lens>
         <maker>Canon</maker>
         <model>Canon EF 22-55mm f/4-5.6 USM</model>
-        <mount>Canon EF-S</mount>
+        <mount>Canon EF</mount>
         <cropfactor>1.613</cropfactor>
         <calibration>
             <!-- Taken with EOS 750D -->


### PR DESCRIPTION
All were incorrectly listed as EF-S. Found and fixed by @rebio.
Fixes #1650.