### PR TITLE
Update slr-nikon.xml

### DIFF
--- a/data/db/slr-nikon.xml
+++ b/data/db/slr-nikon.xml
@@ -5456,7 +5456,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>Nikon AF-S VR Nikkor 400mm f_2.8G ED</model>
+        <model>Nikon AF-S VR Nikkor 400mm f/2.8G ED</model>
         <mount>Nikon AF F</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>


### PR DESCRIPTION
Changed Lens Name to make it consistent:

```
$ exiv2 -pt 20181009_n5x7096.nef | grep -ai lens
Exif.Nikon3.LensType                         Byte        1  D G VR
Exif.Nikon3.Lens                             Rational    4  400mm F2.8
Exif.Nikon3.LensFStops                       Undefined   4  6
Exif.NikonLd3.LensIDNumber                   Byte        1  Nikon AF-S VR Nikkor 400mm f/2.8G ED
Exif.NikonLd3.LensFStops                     Byte        1  F6.0
```
```
$ exiftool 20181009_n5x7096.nef | grep -i lens
Lens Type                       : G VR
Lens                            : 400mm f/2.8
Lens F Stops                    : 6.00
Lens Focus Function Buttons     : AF Lock Only
Lens Data Version               : 0204
Lens ID Number                  : 150
Lens F Stops                    : 6.00
Lens ID                         : AF-S VR Nikkor 400mm f/2.8G ED
Lens Spec                       : 400mm f/2.8 G VR
```
(came across this because darktable could not find the lens)