### PR TITLE
add complete model names for Lumix G Vario 14-140mm f/3.5-5.6 vers.…

### DIFF
--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -1907,6 +1907,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 14-140mm f/3.5-5.6</model>
+        <model lang="en">Lumix G Vario 14-140mm f/3.5-5.6 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1998,6 +1999,7 @@
         <!-- copy of the non-"II" profile, optics reported to be the same -->
         <maker>Panasonic</maker>
         <model>Lumix G Vario 14-140mm f/3.5-5.6 II</model>
+        <model lang="en">Lumix G Vario 14-140mm f/3.5-5.6 Asph. II Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>


### PR DESCRIPTION
… I and II

Also enables automatic lens detection in darktable for pictures taken with lens version I and Olympus E-M10.
fixes #1801 and #1803 