### PR TITLE
added Sony Alpha 7R IIIa

### DIFF
--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -151,6 +151,14 @@
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
     </camera>
+    
+    <camera>
+        <maker>Sony</maker>
+        <model>ILCE-7RM3A</model>
+        <model lang="en">Alpha 7R IIIa</model>
+        <mount>Sony E</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
 
     <camera>
         <maker>Sony</maker>

--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -155,7 +155,7 @@
     <camera>
         <maker>Sony</maker>
         <model>ILCE-7RM3A</model>
-        <model lang="en">Alpha 7R IIIa</model>
+        <model lang="en">Alpha 7R IIIA</model>
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
     </camera>


### PR DESCRIPTION
Configuration for the Sony Alpha 7R IIIa. This is the 2021 edition of the 7R III launched in 2018. New model devices require this config for the camera to be properly detected.

More info here: https://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-7rm3a