### PR TITLE
Added Pentax K-3 Mark III

### DIFF
--- a/data/db/slr-pentax.xml
+++ b/data/db/slr-pentax.xml
@@ -275,7 +275,7 @@
         <maker>Ricoh Imaging Company, Ltd.</maker>
         <maker lang="en">Pentax</maker>
         <model>Pentax K-3 Mark III</model>
-        <model lang="en">K-3 Mark III</model>
+        <model lang="en">K-3 III</model>
         <mount>Pentax KAF2</mount>
         <cropfactor>1.546</cropfactor>
     </camera>

--- a/data/db/slr-pentax.xml
+++ b/data/db/slr-pentax.xml
@@ -270,6 +270,15 @@
         <mount>Pentax KAF2</mount>
         <cropfactor>1.534</cropfactor>
     </camera>
+    
+    <camera>
+        <maker>Ricoh Imaging Company, Ltd.</maker>
+        <maker lang="en">Pentax</maker>
+        <model>Pentax K-3 Mark III</model>
+        <model lang="en">K-3 Mark III</model>
+        <mount>Pentax KAF2</mount>
+        <cropfactor>1.546</cropfactor>
+    </camera>
 
     <camera>
         <maker>Ricoh Imaging Company, Ltd.</maker>


### PR DESCRIPTION
Added the configuration for the Pentax K-3 Mark III launched in 2021. 

Details: https://www.ricoh-imaging.eu/de_de/pentax-k-3-mark-iii

I calculated the cropfactor by using the sensor dimensions from the datasheet `(√(24^2+36^2))÷(√(23,3^2+15,5^2))=1,546`

The naming was taken from the EXIF-Data of an image.