### PR TITLE
Added Tokina 12-28 name from Canon mount

### DIFF
--- a/data/db/slr-tokina.xml
+++ b/data/db/slr-tokina.xml
@@ -473,6 +473,7 @@
     <lens>
         <maker>Tokina</maker>
         <model>Tokina AF 12-28mm f/4 AT-X Pro DX</model>
+        <model>Tokina AT-X 12-28 PRO DX 12-28mm f/4</model>
         <mount>Canon EF</mount>
         <mount>Nikon F AF</mount>
         <cropfactor>1.534</cropfactor>


### PR DESCRIPTION
Added alternate model name for Tokina AT-X 12-28mm PRO DX f/4 as reported by exiv2 on Canon 90D (EF mount).

Output of `exiv2 -pv 2022-06-07-10-55-57-IMG_0489.CR3 | grep -ai lens`
```
0xa432 Photo        LensSpecification           Rational    4  12/1 28/1 0/1 0/1
0xa434 Photo        LensModel                   Ascii       1
0xa435 Photo        LensSerialNumber            Ascii      11  0000000000
0x0016 CanonCs      LensType                    Short       1  234
0x0017 CanonCs      Lens                        Short       3  28 12 1
0x003d CanonFi      RFLensType                  SShort      1  0
0x0095 Canon        LensModel                   Ascii     138
```

Output of `exiv2 -pt 2022-06-07-10-55-57-IMG_0489.CR3 | grep -ai lens`
```
Exif.Photo.LensSpecification                 Rational    4  12/1 28/1 0/1 0/1
Exif.Photo.LensModel                         Ascii       1
Exif.Photo.LensSerialNumber                  Ascii      11  0000000000
Exif.CanonCs.LensType                        Short       1  Tokina AT-X 12-28 PRO DX 12-28mm f/4
Exif.CanonCs.Lens                            Short       3  12.0 - 28.0 mm
Exif.CanonFi.RFLensType                      SShort      1  n/a
Exif.Canon.LensModel                         Ascii     138
```
