### PR TITLE
Add distortion correction for TTArtisan APS-C 23mm F1.4.

### DIFF
--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -850,8 +850,7 @@
         <mount>Leica L</mount>
         <focal value="23"/>
         <aperture min="1.4" max="16"/>
-        <type>rectilinear</type>
-        <cropfactor>1.5</cropfactor>
+        <cropfactor>1.534</cropfactor>
         <calibration>
             <!-- Taken with Sony ILCE-6000 -->
             <distortion focal="23" model="ptlens" a="0.0161337237089191" b="-0.0482754569770453" c="0.0238347937460166"/>

--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -839,6 +839,26 @@
     </lens>
 
     <lens>
+        <maker>TTArtisan</maker>
+        <model>TTArtisan APS-C 23mm F1.4</model>
+        <mount>Sony E</mount>
+        <mount>Fujifilm X</mount>
+        <mount>Canon EF-M</mount>
+        <mount>Canon RF</mount>
+        <mount>Nikon Z</mount>
+        <mount>Micro 4/3 System</mount>
+        <mount>Leica L</mount>
+        <focal value="23"/>
+        <aperture min="1.4" max="16"/>
+        <type>rectilinear</type>
+        <cropfactor>1.5</cropfactor>
+        <calibration>
+            <!-- Taken with Sony ILCE-6000 -->
+            <distortion focal="23" model="ptlens" a="0.0161337237089191" b="-0.0482754569770453" c="0.0238347937460166"/>
+        </calibration>
+    </lens>
+
+    <lens>
         <maker>Chinon</maker>
         <model>Auto Chinon 35mm f/2.8</model>
         <mount>M42</mount>


### PR DESCRIPTION
This is a fully manual lens with no EXIF data transmission.

I listed all mounts in which the lens is available, but I don't know whether it's correct given the crop factor differs among the mounts.

Also, I was not sure about the order in which the lenses should be added to misc.xml, so I added it after the last Venus Laowa lens as TTartisan is yet another Chinese brand.