### PR TITLE
change model name for Sigma 56mm F1.4 DC DN | Contemporary 018

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -96,7 +96,7 @@
 
     <lens>
         <maker>Sigma</maker>
-        <model>56mm F1.4 DC DN | Contemporary 018</model>
+        <model>Sigma 56mm F1.4 DC DN | Contemporary 018</model>
         <model lang="en">Sigma 56 mm F1.4 DC DN | C 018</model>
         <mount>Sony E</mount>
         <mount>Fujifilm X</mount>


### PR DESCRIPTION
change model name for better automatic lens detection (e.g. for Fujifilm images)
fixes #1846