### PR TITLE
add distortion correction for Sigma 28-70mm F2.8 DG DN | C 021

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -695,4 +695,21 @@
         </calibration>
     </lens>
 
+    <lens>
+        <maker>Sigma</maker>
+        <model>28-70mm F2.8 DG DN | Contemporary 021</model>
+        <mount>Sony E</mount>
+        <mount>Leica L</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+            <!-- Taken with Panasonic Lumix DC-S5 -->
+            <distortion model="ptlens" focal="28.0" a="0.0231531" b="-0.0602009" c="0.00137773"/>
+            <distortion model="ptlens" focal="32.0" a="0.019141" b="-0.0437372" c="0.00220297"/>
+            <distortion model="ptlens" focal="42.0" a="0.0106437" b="-0.011167" c="-0.00572176"/>
+            <distortion model="ptlens" focal="50.0" a="0.01185" b="-0.0154665" c="0.0156092"/>
+            <distortion model="ptlens" focal="56.0" a="0.0124585" b="-0.0180694" c="0.0237966"/>
+            <distortion model="ptlens" focal="70.0" a="0.0143533" b="-0.0188212" c="0.0189676"/>
+        </calibration>
+    </lens>
+
 </lensdatabase>


### PR DESCRIPTION
fixes #1848
Unfortunately the automatic lens detection in darktable does not work with panasonic cameras and this lens at the moment. With Sony cameras, the automatic detection works correctly.
@sarunasb: do you have any ideas what the reason for that could be? Is the cause in exiv2 or darktable? [2 pictures more](https://jonani1.my-router.de/nextcloud/index.php/s/e7pQPnSZoS6LLnH)