### PR TITLE
add Pentax KAF2 and 4/3 system mounts to Sigma 70-200mm f/2.8 EX DG OS HSM

### DIFF
--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -2537,6 +2537,8 @@
         <mount>Nikon F AF</mount>
         <mount>Sony Alpha</mount>
         <mount>Canon EF</mount>
+        <mount>Pentax KAF2</mount>
+        <mount>4/3 System</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
             <!-- Taken with Sony NEX-7 -->


### PR DESCRIPTION
fixes #1881