### PR TITLE
release 0.3.x: Backport 694542f350fc7c9ccafa2d9acb4d4e00e690cbdc to fix compilation …

### DIFF
--- a/libs/lensfun/cpuid.cpp
+++ b/libs/lensfun/cpuid.cpp
@@ -92,9 +92,9 @@ guint _lf_detect_cpu_features ()
 {
 #define cpuid(cmd) \
     __asm volatile ( \
-        "push %%"R_BX"\n" \
+        "push %%" R_BX "\n" \
         "cpuid\n" \
-        "pop %%"R_BX"\n" \
+        "pop %%" R_BX "\n" \
        : "=a" (ax), "=c" (cx),  "=d" (dx) \
        : "0" (cmd))
 

--- a/tests/test_modifier.cpp
+++ b/tests/test_modifier.cpp
@@ -78,8 +78,8 @@ void test_mod_projection_center(lfFixture* lfFix, gconstpointer data)
 // check if output becomes NaN when processing geometry conversion
 void test_mod_projection_borders(lfFixture* lfFix, gconstpointer data)
 {
-    float in[2]  = {lfFix->img_width, lfFix->img_height};
-    float in2[2] = {(lfFix->img_width-1)/2, (lfFix->img_height-1)/2};
+    float in[2]  = {(float) lfFix->img_width, (float) lfFix->img_height};
+    float in2[2] = {(float) (lfFix->img_width-1)/2, (float) (lfFix->img_height-1)/2};
     float res[2] = {0, 0};
 
     lfLensType geom_types [] = {LF_RECTILINEAR, LF_PANORAMIC, LF_EQUIRECTANGULAR, LF_FISHEYE_STEREOGRAPHIC, LF_FISHEYE, LF_FISHEYE_EQUISOLID, LF_FISHEYE_ORTHOGRAPHIC, LF_FISHEYE_THOBY, LF_UNKNOWN};


### PR DESCRIPTION
…with clang (fixes #1954)