### PR TITLE
Release 0.3.x: Bump CMake minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# require at least cmake 2.8
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8 FATAL_ERROR )
+# require at least cmake 2.8.12
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR )
 
 # path for helper modules
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/modules")


### PR DESCRIPTION
The previous minimum version (2.8) will be deprecated.