### PR TITLE
Make Meike 28mm f/2.8 lens name consistent with other Meike's names

### DIFF
--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -743,7 +743,7 @@
 
     <lens>
         <maker>Meike</maker>
-        <model>Meike MK-F 28mm f/2.8</model>
+        <model>Meike 28mm f/2.8</model>
         <mount>Fujifilm X</mount>
         <mount>Micro 4/3 System</mount>
         <mount>Sony E</mount>


### PR DESCRIPTION
Hello there. Please consider this little fix for non-exif Meike lens.