### PR TITLE
Added support for Olympus E-M10 Mark III S

### DIFF
--- a/data/db/mil-olympus.xml
+++ b/data/db/mil-olympus.xml
@@ -199,6 +199,7 @@
         <maker>Olympus Corporation</maker>
         <maker lang="en">Olympus</maker>
         <model>E-M10 Mark III</model>
+        <model>E-M10MarkIIIS</model>
         <model lang="en">E-M10 III</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>


### PR DESCRIPTION
When editing my RAW photos of the Olympus E-M10 Mark III S in Darktable, I always had to manually set the correct camera model. But in principle it is the E-M10 Mark III with silent shutter. 

Now I was tired of it and found a solution. If the multiple use of "model" is not desired, one can of course still add a separate "camera" entry. So it has now worked for me, however!