### PR TITLE
use threadsafe uselocal (_configthreadlocale for Windows)

### DIFF
--- a/libs/lensfun/database.cpp
+++ b/libs/lensfun/database.cpp
@@ -738,9 +738,14 @@ lfError lfDatabase::Load (const char *errcontext, const char *data, size_t data_
     };
 
     /* Temporarily drop numeric format to "C" */
-    char *old_numeric = setlocale (LC_NUMERIC, NULL);
-    old_numeric = strdup(old_numeric);
-    setlocale(LC_NUMERIC,"C");
+#if defined(_MSC_VER)
+    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+    setlocale (LC_NUMERIC, "C");
+#else
+    auto loc = uselocale((locale_t) 0); // get current local
+    auto nloc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+    uselocale(nloc);
+#endif
 
     /* eek! GPtrArray does not have a method to insert a pointer
      into middle of the array... We have to remove the trailing
@@ -777,8 +782,12 @@ lfError lfDatabase::Load (const char *errcontext, const char *data, size_t data_
     g_ptr_array_add ((GPtrArray *)Lenses, NULL);
 
     /* Restore numeric format */
-    setlocale (LC_NUMERIC, old_numeric);
-    free(old_numeric);
+#if defined(_MSC_VER)
+    _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
+#else
+    uselocale(loc);
+    freelocale(nloc);
+#endif
 
     return e;
 }
@@ -828,9 +837,14 @@ char *lfDatabase::Save (const lfMount *const *mounts,
                         const lfLens *const *lenses)
 {
     /* Temporarily drop numeric format to "C" */
-    char *old_numeric = setlocale (LC_NUMERIC, NULL);
-    old_numeric = strdup(old_numeric);
-    setlocale(LC_NUMERIC,"C");
+#if defined(_MSC_VER)
+    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+    setlocale (LC_NUMERIC, "C");
+#else
+    auto loc = uselocale((locale_t) 0); // get current local
+    auto nloc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+    uselocale(nloc);
+#endif
 
     int i, j;
     GString *output = g_string_sized_new (1024);
@@ -1074,8 +1088,12 @@ char *lfDatabase::Save (const lfMount *const *mounts,
     g_string_append (output, "</lensdatabase>\n");
 
     /* Restore numeric format */
-    setlocale (LC_NUMERIC, old_numeric);
-    free(old_numeric);
+#if defined(_MSC_VER)
+    _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
+#else
+    uselocale(loc);
+    freelocale(nloc);
+#endif
 
     return g_string_free (output, FALSE);
 }

--- a/libs/lensfun/lens.cpp
+++ b/libs/lensfun/lens.cpp
@@ -248,9 +248,14 @@ void lfLens::GuessParameters ()
     float minf = float (INT_MAX), maxf = float (INT_MIN);
     float mina = float (INT_MAX), maxa = float (INT_MIN);
 
-    char *old_numeric = setlocale (LC_NUMERIC, NULL);
-    old_numeric = strdup (old_numeric);
+#if defined(_MSC_VER)
+    _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     setlocale (LC_NUMERIC, "C");
+#else
+    auto loc = uselocale((locale_t) 0); // get current local
+    auto nloc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+    uselocale(nloc);
+#endif
 
     if (Model && (!MinAperture || !MinFocal) &&
         !strstr (Model, "adapter") &&
@@ -334,11 +339,14 @@ void lfLens::GuessParameters ()
     if (maxa != INT_MIN && !MaxAperture)
         MaxAperture = maxa;
 
-    if (!MaxFocal)
-        MaxFocal = MinFocal;
+    if (!MaxFocal) MaxFocal = MinFocal;
 
-    setlocale (LC_NUMERIC, old_numeric);
-    free (old_numeric);
+#if defined(_MSC_VER)
+    _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
+#else
+    uselocale(loc);
+    freelocale(nloc);
+#endif
 }
 
 bool lfLens::Check ()


### PR DESCRIPTION
fixes #1984

Instead of `setlocale()` we can use [uselocal](https://man7.org/linux/man-pages/man3/uselocale.3.html) or [_configthreadlocale](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/configthreadlocale?view=msvc-170) for Windows. Both change the locale only for the lensfun thread.
I did not test if the crash in darktable is fixed but if this `setlocale()` is the issue then it should be.

This should probably be part of the 0.3.4 release.