### PR TITLE
GitHub Actions: MSYS2 workflow

### DIFF
--- a/.github/workflows/cmake-msys2.yml
+++ b/.github/workflows/cmake-msys2.yml
@@ -1,0 +1,36 @@
+name: CMake-MSYS2
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  msys2-ucrt64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          pacboy: >-
+            cmake:p
+            cc:p
+            glib2:p
+            libxml2:p
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/libs/lensfun/database.cpp
+++ b/libs/lensfun/database.cpp
@@ -819,7 +819,7 @@ lfError lfDatabase::Load (const char *errcontext, const char *data, size_t data_
     };
 
     /* Temporarily drop numeric format to "C" */
-#if defined(_MSC_VER)
+#if defined(PLATFORM_WINDOWS)
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     setlocale (LC_NUMERIC, "C");
 #else
@@ -851,7 +851,7 @@ lfError lfDatabase::Load (const char *errcontext, const char *data, size_t data_
     g_markup_parse_context_free (mpc);
 
     /* Restore numeric format */
-#if defined(_MSC_VER)
+#if defined(PLATFORM_WINDOWS)
     _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
 #else
     uselocale(loc);
@@ -894,7 +894,7 @@ char *lfDatabase::Save () const
 lfError lfDatabase::Save (char*& xml, size_t& data_size) const
 {
     /* Temporarily drop numeric format to "C" */
-#if defined(_MSC_VER)
+#if defined(PLATFORM_WINDOWS)
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     setlocale (LC_NUMERIC, "C");
 #else
@@ -1137,7 +1137,7 @@ lfError lfDatabase::Save (char*& xml, size_t& data_size) const
     g_string_append (output, "</lensdatabase>\n");
 
     /* Restore numeric format */
-#if defined(_MSC_VER)
+#if defined(PLATFORM_WINDOWS)
     _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
 #else
     uselocale(loc);

--- a/libs/lensfun/lens.cpp
+++ b/libs/lensfun/lens.cpp
@@ -171,7 +171,7 @@ void lfLens::GuessParameters ()
     float minf = float (INT_MAX), maxf = float (INT_MIN);
     float mina = float (INT_MAX), maxa = float (INT_MIN);
 
-#if defined(_MSC_VER)
+#if defined(PLATFORM_WINDOWS)
     _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
     setlocale (LC_NUMERIC, "C");
 #else
@@ -264,7 +264,7 @@ void lfLens::GuessParameters ()
 
     if (!MaxFocal) MaxFocal = MinFocal;
 
-#if defined(_MSC_VER)
+#if defined(PLATFORM_WINDOWS)
     _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
 #else
     uselocale(loc);


### PR DESCRIPTION
Windows build with [MSYS2](https://www.msys2.org/) using https://github.com/marketplace/actions/setup-msys2.
In comparison to the CMake-Windows workflow, it uses GCC instead of MSVC and installing glib2 is way faster.

Would have caught  https://github.com/lensfun/lensfun/issues/1998.
On top of https://github.com/lensfun/lensfun/pull/1999, so the build doesn't fail.