### PR TITLE
vignetting data for Canon RF 24-70mm f/2.8 L IS USM

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -1191,6 +1191,77 @@
             <distortion model="ptlens" focal="50" a="0.00135005" b="0.0040131" c="-0.00177737"/>
             <distortion model="ptlens" focal="58" a="0.0012503" b="0.00371153" c="0.00370853"/>
             <distortion model="ptlens" focal="70" a="-0.00796799" b="0.0352717" c="-0.0302904"/>
+            <!-- Taken with Canon EOS R6 Mark II -->
+            <vignetting model="pa" focal="24" aperture="2.8" distance="10" k1="-0.5654" k2="-0.9197" k3="0.7083"/>
+            <vignetting model="pa" focal="24" aperture="2.8" distance="1000" k1="-0.5654" k2="-0.9197" k3="0.7083"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="10" k1="-0.5853" k2="-0.2026" k3="0.1265"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="1000" k1="-0.5853" k2="-0.2026" k3="0.1265"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="10" k1="-0.7571" k2="0.3014" k3="-0.1503"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="1000" k1="-0.7571" k2="0.3014" k3="-0.1503"/>
+            <vignetting model="pa" focal="24" aperture="8" distance="10" k1="-0.6774" k2="0.0560" k3="0.0643"/>
+            <vignetting model="pa" focal="24" aperture="8" distance="1000" k1="-0.6774" k2="0.0560" k3="0.0643"/>
+            <vignetting model="pa" focal="24" aperture="22" distance="10" k1="-0.6455" k2="-0.0165" k3="0.1074"/>
+            <vignetting model="pa" focal="24" aperture="22" distance="1000" k1="-0.6455" k2="-0.0165" k3="0.1074"/>
+            <vignetting model="pa" focal="31" aperture="2.8" distance="10" k1="-0.5881" k2="-0.1696" k3="0.0799"/>
+            <vignetting model="pa" focal="31" aperture="2.8" distance="1000" k1="-0.5881" k2="-0.1696" k3="0.0799"/>
+            <vignetting model="pa" focal="31" aperture="4" distance="10" k1="-0.6159" k2="0.3321" k3="-0.2508"/>
+            <vignetting model="pa" focal="31" aperture="4" distance="1000" k1="-0.6159" k2="0.3321" k3="-0.2508"/>
+            <vignetting model="pa" focal="31" aperture="5.6" distance="10" k1="-0.5222" k2="-0.0042" k3="0.0825"/>
+            <vignetting model="pa" focal="31" aperture="5.6" distance="1000" k1="-0.5222" k2="-0.0042" k3="0.0825"/>
+            <vignetting model="pa" focal="31" aperture="8" distance="10" k1="-0.5253" k2="0.0006" k3="0.0803"/>
+            <vignetting model="pa" focal="31" aperture="8" distance="1000" k1="-0.5253" k2="0.0006" k3="0.0803"/>
+            <vignetting model="pa" focal="31" aperture="22" distance="10" k1="-0.5314" k2="0.0096" k3="0.0762"/>
+            <vignetting model="pa" focal="31" aperture="22" distance="1000" k1="-0.5314" k2="0.0096" k3="0.0762"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="10" k1="-0.6149" k2="0.1238" k3="-0.1826"/>
+            <vignetting model="pa" focal="35" aperture="2.8" distance="1000" k1="-0.6149" k2="0.1238" k3="-0.1826"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="10" k1="-0.5860" k2="0.4987" k3="-0.4163"/>
+            <vignetting model="pa" focal="35" aperture="4" distance="1000" k1="-0.5860" k2="0.4987" k3="-0.4163"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="10" k1="-0.4460" k2="-0.0179" k3="0.0656"/>
+            <vignetting model="pa" focal="35" aperture="5.6" distance="1000" k1="-0.4460" k2="-0.0179" k3="0.0656"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="10" k1="-0.4534" k2="-0.0339" k3="0.0906"/>
+            <vignetting model="pa" focal="35" aperture="8" distance="1000" k1="-0.4534" k2="-0.0339" k3="0.0906"/>
+            <vignetting model="pa" focal="35" aperture="22" distance="10" k1="-0.4680" k2="-0.0040" k3="0.0721"/>
+            <vignetting model="pa" focal="35" aperture="22" distance="1000" k1="-0.4680" k2="-0.0040" k3="0.0721"/>
+            <vignetting model="pa" focal="42" aperture="2.8" distance="10" k1="-0.6503" k2="0.3433" k3="-0.3627"/>
+            <vignetting model="pa" focal="42" aperture="2.8" distance="1000" k1="-0.6503" k2="0.3433" k3="-0.3627"/>
+            <vignetting model="pa" focal="42" aperture="4" distance="10" k1="-0.5735" k2="0.6377" k3="-0.5496"/>
+            <vignetting model="pa" focal="42" aperture="4" distance="1000" k1="-0.5735" k2="0.6377" k3="-0.5496"/>
+            <vignetting model="pa" focal="42" aperture="5.6" distance="10" k1="-0.4517" k2="0.1466" k3="-0.0756"/>
+            <vignetting model="pa" focal="42" aperture="5.6" distance="1000" k1="-0.4517" k2="0.1466" k3="-0.0756"/>
+            <vignetting model="pa" focal="42" aperture="8" distance="10" k1="-0.4440" k2="0.0315" k3="0.0522"/>
+            <vignetting model="pa" focal="42" aperture="8" distance="1000" k1="-0.4440" k2="0.0315" k3="0.0522"/>
+            <vignetting model="pa" focal="42" aperture="22" distance="10" k1="-0.4180" k2="0.0036" k3="0.0569"/>
+            <vignetting model="pa" focal="42" aperture="22" distance="1000" k1="-0.4180" k2="0.0036" k3="0.0569"/>
+            <vignetting model="pa" focal="50" aperture="2.8" distance="10" k1="-0.6712" k2="0.3996" k3="-0.3980"/>
+            <vignetting model="pa" focal="50" aperture="2.8" distance="1000" k1="-0.6712" k2="0.3996" k3="-0.3980"/>
+            <vignetting model="pa" focal="50" aperture="4" distance="10" k1="-0.5081" k2="0.6394" k3="-0.6064"/>
+            <vignetting model="pa" focal="50" aperture="4" distance="1000" k1="-0.5081" k2="0.6394" k3="-0.6064"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="10" k1="-0.4348" k2="0.2726" k3="-0.1962"/>
+            <vignetting model="pa" focal="50" aperture="5.6" distance="1000" k1="-0.4348" k2="0.2726" k3="-0.1962"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="10" k1="-0.3682" k2="-0.0015" k3="0.0543"/>
+            <vignetting model="pa" focal="50" aperture="8" distance="1000" k1="-0.3682" k2="-0.0015" k3="0.0543"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="10" k1="-0.3666" k2="0.0001" k3="0.0509"/>
+            <vignetting model="pa" focal="50" aperture="22" distance="1000" k1="-0.3666" k2="0.0001" k3="0.0509"/>
+            <vignetting model="pa" focal="58" aperture="2.8" distance="10" k1="-0.8161" k2="0.5947" k3="-0.4636"/>
+            <vignetting model="pa" focal="58" aperture="2.8" distance="1000" k1="-0.8161" k2="0.5947" k3="-0.4636"/>
+            <vignetting model="pa" focal="58" aperture="4" distance="10" k1="-0.4843" k2="0.6471" k3="-0.6506"/>
+            <vignetting model="pa" focal="58" aperture="4" distance="1000" k1="-0.4843" k2="0.6471" k3="-0.6506"/>
+            <vignetting model="pa" focal="58" aperture="5.6" distance="10" k1="-0.4404" k2="0.3944" k3="-0.3063"/>
+            <vignetting model="pa" focal="58" aperture="5.6" distance="1000" k1="-0.4404" k2="0.3944" k3="-0.3063"/>
+            <vignetting model="pa" focal="58" aperture="8" distance="10" k1="-0.3347" k2="-0.0107" k3="0.0559"/>
+            <vignetting model="pa" focal="58" aperture="8" distance="1000" k1="-0.3347" k2="-0.0107" k3="0.0559"/>
+            <vignetting model="pa" focal="58" aperture="22" distance="10" k1="-0.3374" k2="-0.0020" k3="0.0499"/>
+            <vignetting model="pa" focal="58" aperture="22" distance="1000" k1="-0.3374" k2="-0.0020" k3="0.0499"/>
+            <vignetting model="pa" focal="70" aperture="2.8" distance="10" k1="-0.8668" k2="0.7177" k3="-0.4994"/>
+            <vignetting model="pa" focal="70" aperture="2.8" distance="1000" k1="-0.8668" k2="0.7177" k3="-0.4994"/>
+            <vignetting model="pa" focal="70" aperture="4" distance="10" k1="-0.4076" k2="0.4778" k3="-0.5193"/>
+            <vignetting model="pa" focal="70" aperture="4" distance="1000" k1="-0.4076" k2="0.4778" k3="-0.5193"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="10" k1="-0.3575" k2="0.2724" k3="-0.2137"/>
+            <vignetting model="pa" focal="70" aperture="5.6" distance="1000" k1="-0.3575" k2="0.2724" k3="-0.2137"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="10" k1="-0.2930" k2="-0.0162" k3="0.0537"/>
+            <vignetting model="pa" focal="70" aperture="8" distance="1000" k1="-0.2930" k2="-0.0162" k3="0.0537"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="10" k1="-0.3010" k2="-0.0001" k3="0.0450"/>
+            <vignetting model="pa" focal="70" aperture="22" distance="1000" k1="-0.3010" k2="-0.0001" k3="0.0450"/>
         </calibration>
     </lens>
 


### PR DESCRIPTION
Created using Lacerta Flat Field Generator, three images per focal length and apperture. Used the focal lengths for which there is already distortion data.

I can provide the processed data (*.gp and *.dat) and the original raw samples if needed. There are multiple documents on how to contribute and I wasn't sure which one is the latest.