### PR TITLE
Fix typos in data and docs subdirs

### DIFF
--- a/data/db/compact-panasonic.xml
+++ b/data/db/compact-panasonic.xml
@@ -356,7 +356,7 @@
     </camera>
 
     <camera>
-        <!-- German verson of TZ60 -->
+        <!-- German version of TZ60 -->
         <maker>Panasonic</maker>
         <model>DMC-TZ61</model>
         <mount>panasonicTZ70</mount>
@@ -387,7 +387,7 @@
     </camera>
 
     <camera>
-        <!-- North American verson of TZ70 -->
+        <!-- North American version of TZ70 -->
         <maker>Panasonic</maker>
         <model>DMC-ZS50</model>
         <mount>panasonicTZ70</mount>

--- a/data/db/mil-fujifilm.xml
+++ b/data/db/mil-fujifilm.xml
@@ -1664,7 +1664,7 @@
         <mount>Fujifilm X</mount>
         <cropfactor>1.528</cropfactor>
         <calibration>
-	    <!-- cloned from XF35mmF2 R WR, which is optically indentical -->
+	    <!-- cloned from XF35mmF2 R WR, which is optically identical -->
             <!-- Taken with Fujifilm X-Pro2 -->
             <distortion model="ptlens" focal="35" a="0.00956" b="-0.07057" c="0.07334"/>
             <!-- Taken with Fujifilm X-E2 -->

--- a/data/db/mil-samyang.xml
+++ b/data/db/mil-samyang.xml
@@ -281,7 +281,7 @@
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="18" a="0.02072794438055051" b="-0.055421093067902875" c="0.022351964872009425" />
         </calibration>
     </lens>
@@ -292,7 +292,7 @@
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se, except tca -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se, except tca -->
             <distortion model="ptlens" focal="75" a="-0.0014565" b="0.0036664" c="-0.0018816" />
             <tca model="poly3" focal="75" vr="0.9999345" vb="0.9999558"/> 
             <vignetting model="pa" focal="75" aperture="1.8" distance="147.16" k1="-0.8826677" k2="0.3580256" k3="-0.1027655" />
@@ -309,7 +309,7 @@
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se, except tca -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se, except tca -->
             <distortion model="ptlens" focal="35" a="0.0122154" b="-0.0474074" c="0.0348816" />
             <tca model="poly3" focal="35" vr="1.0001321" vb="0.9999907"/>
             <vignetting model="pa" focal="35" aperture="1.8" distance="68.68" k1="-1.4568366" k2="0.8730748" k3="-0.2082213" />

--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -803,7 +803,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="20" a="0.0268937" b="-0.0982549" c="0.0452197" />
             <tca model="poly3" focal="20" vr="1.0003052" cr="-0.0000000" br="0.0000000" vb="1.0000539" cb="-0.0000762" bb="0.0000259" />
         </calibration>
@@ -816,7 +816,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="24" a="0.0178656" b="-0.0739538" c="0.0316300" />
             <tca model="poly3" focal="24" vr="1.0001423" cr="-0.0002125" br="0.0001224" vb="0.9999575" cb="0.0004025" bb="-0.0002176" />
         </calibration>
@@ -829,7 +829,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="24" a="0.0404125" b="-0.1209515" c="0.0644292" />
             <distortion model="ptlens" focal="25" a="0.0403228" b="-0.1182433" c="0.0617783" />
             <distortion model="ptlens" focal="35" a="0.0147573" b="-0.0365721" c="0.0191533" />
@@ -852,7 +852,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="35" a="0.0025850" b="-0.0188551" c="0.0065550" />
             <tca model="poly3" focal="35" vr="1.0001744" cr="0.0000553" br="-0.0000480" vb="1.0000087" cb="-0.0000553" bb="0.0000480" />
         </calibration>
@@ -865,7 +865,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="65" a="-0.0013239" b="0.0100205" c="-0.0016762" />
             <tca model="poly3" focal="65" vr="1.0003439" cr="-0.0001381" br="0.0000462" vb="0.9998513" cb="-0.0000247" bb="0.0000400" />
         </calibration>
@@ -878,7 +878,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="90" a="0.0007308" b="0.0133346" c="0.0007317" />
             <tca model="poly3" focal="90" vr="0.9996588" cr="0.0000772" br="0.0000596" vb="1.0002673" cb="-0.0000573" bb="-0.0001346" />
         </calibration>
@@ -908,7 +908,7 @@
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="16" a="0.0178440" b="-0.0567002" c="0.0100099" />
             <distortion model="ptlens" focal="18" a="0.0155075" b="-0.0359606" c="0.0028970" />
             <distortion model="ptlens" focal="20" a="0.0115102" b="-0.0123447" c="-0.0074466" />

--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -2812,7 +2812,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7RM2, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7RM2, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="50" a="0.00116024" b="-0.0027403" c="0.0013905"/>
             <tca model="poly3" focal="50" vr="1.0004413377609198" cr="0.00013675000622646614" br="-0.0002127673140892765" vb="0.9996095913621427" cb="-5.188427342598107e-05" bb="0.00018776778424975786"/>
         </calibration>
@@ -2857,7 +2857,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-1, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-1, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="14" a="0.0173275" b="-0.0626253" c="0.0548364"/>
             <tca model="poly3" focal="14" vr="0.9999734" cr="0.0001692" br="-0.0000873" vb="1.0000057" cb="0.0000889" bb="-0.0000217"/>
             <vignetting model="pa" focal="14" aperture="1.8" distance="10" k1="-1.6147562" k2="1.2431538" k3="-0.4014634"/>
@@ -2885,7 +2885,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7RM4, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7RM4, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="40" a="-0.0018061" b="-0.0053300" c="-0.0002707"/>
             <tca model="poly3" focal="40" vr="1.0001246" cr="0.0000801" br="-0.0000806" vb="1.0000096" cb="-0.0001158" bb="0.0001091"/>
         </calibration>
@@ -2897,7 +2897,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7RM4, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7RM4, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="50" a="0.0205603" b="-0.0525022" c="0.0357073"/>
             <tca model="poly3" focal="50" vr="1.0003777" cr="-0.0002318" br="0.0000683" vb="0.9999392" cb="0.0001516" bb="-0.0000840"/>
         </calibration>
@@ -3072,7 +3072,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="24" a="0.0169920" b="-0.0493064" c="0.0160732" />
             <distortion model="ptlens" focal="24" a="0.0169920" b="-0.0493064" c="0.0160732" />
             <distortion model="ptlens" focal="34" a="0.0081637" b="-0.0167371" c="0.0089673" />

--- a/data/db/mil-tamron.xml
+++ b/data/db/mil-tamron.xml
@@ -489,7 +489,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7C, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7C, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="35" a="0.0016611115365420873" b="-0.00947386521116718" c="0.003340325675581003" />
             <tca model="poly3" focal="35" vr="1.0001818540335106" cr="6.869199809013899e-05" br="-9.122118693570343e-05" vb="0.9998547038903012" cb="8.492290618014866e-05" bb="3.723618495492444e-05" />
         </calibration>
@@ -501,7 +501,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.5</cropfactor>
         <calibration>
-            <!-- Taken with NEX-6, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with NEX-6, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="24" a="0.0030930" b="-0.0223151" c="0.0085091" />
             <tca model="poly3" focal="24" vr="1.0001424" cr="0.0001191" br="-0.0000649" vb="0.9998416" cb="0.0002908" bb="-0.0000939" />
         </calibration>
@@ -514,7 +514,7 @@
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7M3, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7M3, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="150" a="0.0022672" b="0.0040397" c="0.0022444"/>
             <distortion model="ptlens" focal="220" a="0.0028572" b="0.0057325" c="0.0020892"/>
             <distortion model="ptlens" focal="285" a="0.0027932" b="0.0058954" c="0.0017682"/>

--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -1242,7 +1242,7 @@
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- taken with ILCE-7RM2, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- taken with ILCE-7RM2, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="50" a="0.0025649" b="-0.0051262" c="0.0036677"/>
             <tca model="poly3" focal="50" vr="1.0000000" cr="0.0000000" br="-0.0000000" vb="1.0001221" cb="0.0000000" bb="-0.0000000"/>
             <vignetting model="pa" focal="50" aperture="2.0" distance="0.37" k1="-1.1824744" k2="0.7123001" k3="-0.2028800"/>

--- a/docs/calibration_tutorial/lens_calibration_tutorial.rst
+++ b/docs/calibration_tutorial/lens_calibration_tutorial.rst
@@ -134,7 +134,7 @@ example, you may rename to
 
     Canon_EF_24-70mm_f__2.8L_USM--35mm--2.8.CR2
 
-In the lens name, the following substituions apply, since some characters that
+In the lens name, the following substitutions apply, since some characters that
 occur in lens names are not allowed in (Hugin) filenames:
 
 ===========================  ===============================
@@ -165,7 +165,7 @@ First, have a look at the `screencast at Vimeo`_.  It gives you an overview.
 Additionally, it demonstrates how to do the actual calibration with the `Hugin
 panorama stitcher`_.  Unfortunately, the video refers to an older version of
 Hugin.  Since 2014, Hugin uses a different user interface.  If you know Hugin,
-you probably are able to map the workfow to the new UI.
+you probably are able to map the workflow to the new UI.
 
 .. _`screencast at Vimeo`: https://vimeo.com/51999287
 .. _`Hugin panorama stitcher`: http://hugin.sourceforge.net/

--- a/docs/man/lensfun-convert-lcp.1.rst
+++ b/docs/man/lensfun-convert-lcp.1.rst
@@ -69,7 +69,7 @@ will silently overwrite this file if it was already existing.  The Lensfun
 database is by default searched in these directories (without subdirectories):
 ``/usr/share/lensfun``, ``/usr/share/local/lensfun``,
 ``/var/lib/lensfun-updates``, ``~/.local/share/lensfun/updates``, and
-``~/.local/share/lensfun`` (with later directories overriding ealier ones).
+``~/.local/share/lensfun`` (with later directories overriding earlier ones).
 Note that this database discovery is slightly different from the Lensfun
 library's one.
 

--- a/docs/manual-main.txt
+++ b/docs/manual-main.txt
@@ -187,13 +187,13 @@ necessary.
 
 If you want the updates to be installed system-wide, the program needs root
 privileges.  So call the program with “sudo lensfun‑update‑data” and enter your
-root password.  There exists a second version of the programm called
+root password.  There exists a second version of the program called
 “g‑lensfun‑update‑data”.  It will let you enter the root password – if new data
 is available – in a neat window.  This version is especially useful for GUI
 programs, which can call it in the background.
 
 If it is sufficient that the updates are available to only your user account,
-call “lensfun‑update‑data” without root priviledges.  The updates are then
+call “lensfun‑update‑data” without root privileges.  The updates are then
 written to ~/.local/share/lensfun/updates”.
 
 In case there is more than one version of Lensfun on your system (e.g. you
@@ -284,7 +284,7 @@ split apart for easier maintenance.
 
 The database contains three kinds of objects: @b mounts, @b cameras and @b lenses.
 
-Every @b camera has a mount type assigned (and only one). Similarily, @b lenses
+Every @b camera has a mount type assigned (and only one). Similarly, @b lenses
 also have a list of mounts assigned, because lenses often come in several variants
 with different mounts. Finally, every @b mount has assigned a list of compatible mounts,
 so if your camera has mount B which is compatible with mount A, you can list all the
@@ -435,10 +435,10 @@ compatibility is unidirectional, e.g. in the above example it doesn't say that y
 can insert Pentax KAF2 lenses into a Pentax K camera; if you need a two-way
 compatibility, declare it both ways. Also the “compatibility” is restricted
 in the sense that if mount A is compatible with mount B (e.g. you can put B lenses
-on an A camera), and mount B is compatible with mount C, this does not neccessarily
+on an A camera), and mount B is compatible with mount C, this does not necessarily
 mean that mount A is compatible with mount C. Recursion doesn't work here, this is
 a design decision. If you need to make mount A compatible with mount C, declare it
-so explicitely.
+so explicitly.
 
 Things are slightly complicated with mirrorless systems because they are
 adaptable to virtually any non-mirrorless system.  In order to avoid too many
@@ -541,7 +541,7 @@ Library recognizes several ways to specify lens parameters directly
 in lens model name. The first way to specify lens focal length and
 aperture range is “[min focal]-[max focal]mm f/[min aperture]-[max aperture]”
 where the “mm” and “f/” are totally optional. For primes the 'max'
-values may be omited. Examples:
+values may be omitted. Examples:
 
 <ul>
 <li>70-210mm f/4-5.6
@@ -785,7 +785,7 @@ is as perfect as a rectilinear image if it follows the respective
 projection formula.  And the image follows the projection formula after
 a successful distortion correction.
 
-Therefore, the change of projection is perfomed \a after the image
+Therefore, the change of projection is performed \a after the image
 corrections.
 
 @subsection pc Perspective correction
@@ -806,7 +806,7 @@ assuming the correct focal length, scaling comes last in the processing.
 
 @section actualorder How it is really done
 
-The actual order perfomed in the Lensfun-calling program will differ
+The actual order performed in the Lensfun-calling program will differ
 from the above list.
 
 Why is this?  Understanding this is very important for hacking on
@@ -882,14 +882,14 @@ overview:
     <td>yes</td><td>no</td></tr>
   <tr><td>6</td><td>lines</td><td>(1)–(4) as with 4 control points; (5) & (6) define line perpendicular to the other two</td>
     <td>yes</td><td>yes</td></tr>
-  <tr><td>7</td><td>circle & line</td><td>(1)–(5) as with 5 control points; (6) & (7) define perfectly horizonal or vertical line</td>
+  <tr><td>7</td><td>circle & line</td><td>(1)–(5) as with 5 control points; (6) & (7) define perfectly horizontal or vertical line</td>
     <td>yes</td><td>no</td></tr>
   <tr><td>8</td><td>lines</td><td>(1)–(6) as with 6 control points; (7) & (8) define line parallel to the (5)/(6) line</td>
     <td>no</td><td>yes</td></tr>
 </table>
 
 In this table, “full correction” means that all lines that are parallel in the
-original (horizonal, vertical, diagonal, whatever, as long as they are within
+original (horizontal, vertical, diagonal, whatever, as long as they are within
 the plane) become parallel after the correction.  No full correction means that
 only lines in <i>one</i> direction are corrected.
 
@@ -900,7 +900,7 @@ only lines in <i>one</i> direction are corrected.
 \image html pc-8-points.svg "8 points: two horizontals, two verticals"
 </div>
 <div class="image-landscape">
-\image html pc-6-points.svg "6 points: two verticals, one horizonal"
+\image html pc-6-points.svg "6 points: two verticals, one horizontal"
 </div>
 <div class="image-landscape">
 \image html pc-4-points.svg "4 points: two verticals"
@@ -923,15 +923,15 @@ either way.
 @section circle-based-pc Circle-based correction
 
 <div class="image-landscape">
-\image html pc-7-points.svg "7 points: one circle, one horizonal"
+\image html pc-7-points.svg "7 points: one circle, one horizontal"
 </div>
 <div class="image-landscape">
 \image html pc-5-points.svg "5 points: one circle"
 </div>
 
 Using 5 or 7 control points activates a circle-based correction using an
-ellipse which is supposed to become a circle.  Mathematicaly, 5 points define
-an ellipse.  Two additional points may be used to define a horizonal or
+ellipse which is supposed to become a circle.  Mathematically, 5 points define
+an ellipse.  Two additional points may be used to define a horizontal or
 vertical line, whichever is closer.
 
 There is, unfortunately, an ambiguity to sort out: A circle may become an
@@ -956,7 +956,7 @@ some extreme cases, the original centre cannot be displayed anymore because it
 is beyond the vertex.  Then, the centre of the control points is used
 instead.</li>
 <li>It scales the image so that the centre of the image keeps its scale.</li>
-<li>It rotates the image so that lines supposed to be vertical or horizonal actually are.</li>
+<li>It rotates the image so that lines supposed to be vertical or horizontal actually are.</li>
 </ul>
 
 @section pc-d-parameter The d parameter for fine-tuning
@@ -1005,7 +1005,7 @@ get the control point coordinates.
 Control points are given using their pixel coordinates.  The origin of the
 coordinate system is in the top left corner, with the first pixel having the
 coordinates (0, 0).  The first coordinate is measured to the right, and the
-second is measured to the bottom.  For best accuracy, the coodinates do not
+second is measured to the bottom.  For best accuracy, the coordinates do not
 refer to the pristine image.  Instead, the following transformations need to
 have been applied when the coordinates are determined:
 
@@ -1094,7 +1094,7 @@ and invoking the respective lfDatabase::Load() method. After that it can look fo
 Lens object using the bits of information from the user or from the source file.
 For example, the EXIF data contains the camera maker and camera model. Using this
 you can search for the respective camera in the database. In camera record you look
-at the mount field, and then do a lens search based on at least mount name. Additionaly,
+at the mount field, and then do a lens search based on at least mount name. Additionally,
 you may provide the lens manufacturer and/or model name from the EXIF data (which is
 not always possible). You get a list of possible lenses. If it's just one lens, you
 can assume that it's exactly the lens that was used to take the shot (this is true
@@ -1108,7 +1108,7 @@ may be modified according to user preferences.
 Lensfun transformations -- at least those involving TCA and vignetting
 correction -- must be applied to linear RGB data in the sensor's original
 colour space. Linear RGB can only be retrieved from RAW files, as JPEG files from 
-most cameras already have colour transfromations applied. This is very important. If you do e.g. 
+most cameras already have colour transformations applied. This is very important. If you do e.g. 
 TCA correction on sRGB data, the colour fringes are still visible.  And if you do 
 vignetting correction after a gamma has been applied, the corners probably will look too
 bright.  So make sure that Lensfun comes early enough in your processing chain.
@@ -1121,7 +1121,7 @@ in the database. Well, that's easy to fix, just add it to the database yourself!
 
 As stated in the section @ref dbsearch, the library will look for xml database files
 in various subdirectories. The best place to put your own definitions into is
-~/.local/share/lensfun/. This directory is guaranteed to not be overwriten by
+~/.local/share/lensfun/. This directory is guaranteed to not be overwritten by
 library or even OS upgrades, so it's safe to keep them there.
 
 So now you just create a new file under ~/.local/share/lensfun/ -- with any name,

--- a/docs/mounts.txt
+++ b/docs/mounts.txt
@@ -3,7 +3,7 @@ Canon:
     FD - Another mount (incompatible with FL) feat. automatic aperture
     EF - Another incompatible mount, EF stands for electro-focus
     EF-S - A newer variant of EF with shorter flange depth, allowing
-           for manufacturing of less expensive wide-angle lenses. Not useable
+           for manufacturing of less expensive wide-angle lenses. Not usable
            on cameras with crop 1.0 and on EF-only cameras.
 
 Contax:


### PR DESCRIPTION
Found via `codespell -q 3 -S *.svg,./ChangeLog,./sourceforge-archive,./berlios-archive -L ist,makro,nd,ois,optio`

Note: The `-S` flag Skips directories/files