### PR TITLE
Fix remaining typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ IF(WIN32)
           SET(NEW_FLAGS "${CMAKE_${TYPE}_FLAGS${CFG}}")
           # fix up static libc flags
           STRING(REPLACE "/MD" "/MT" NEW_FLAGS "${NEW_FLAGS}")
-          # *FORCE* to override whats already placed into the cache
+          # *FORCE* to override what's already placed into the cache
           SET(CMAKE_${TYPE}_FLAGS${CFG} "${NEW_FLAGS}" CACHE STRING
             "CMAKE_${TYPE}_FLAGS${CFG} (overwritten to ensure static build)" FORCE)
         ENDFOREACH(CFG)

--- a/apps/lensfun-convert-lcp
+++ b/apps/lensfun-convert-lcp
@@ -302,7 +302,7 @@ if not lensfun_cameras and not lensfun_lenses:
 
 
 class FieldNotFoundError(Exception):
-    """Raised by `LCPLens.read_field` if an element/atribute with the given
+    """Raised by `LCPLens.read_field` if an element/attribute with the given
     name was not found, and no default was defined.
     """
     pass
@@ -517,7 +517,7 @@ class LCPLens:
 
     def make_model_en_prettier(self):
         """Makes the human-friendly lens model name prettier.  This happens after
-        having matched agains Lensfun names, so in contrast to
+        having matched against Lensfun names, so in contrast to
         `LensfunLens.sanitize_lcp_lens_model_name`, this function only acts on
         ``model_en``, and only for nice GUI entries.
         """

--- a/apps/lenstool/image.cpp
+++ b/apps/lenstool/image.cpp
@@ -1,5 +1,5 @@
 /*
-    Miscelaneous image manipulations
+    Miscellaneous image manipulations
     Copyright (C) 2001 by Andrew Zabolotny
 */
 

--- a/apps/lenstool/lenstool.cpp
+++ b/apps/lenstool/lenstool.cpp
@@ -382,7 +382,7 @@ int main (int argc, char **argv)
         delete ldb;
         g_print ("%s", "\rERROR: Database could not be loaded\n");
         return -1;
-    } else g_print ("%s", "\rDatabase loaded succesfully.\n\n");
+    } else g_print ("%s", "\rDatabase loaded successfully.\n\n");
 
 
     // try to find camera in the database

--- a/apps/lenstool/rgbpixel.h
+++ b/apps/lenstool/rgbpixel.h
@@ -93,16 +93,16 @@ struct RGBpixel
 #undef RGB_MASK
 
 /**
- * Eye sensivity to different color components, from NTSC grayscale equation.
+ * Eye sensitivity to different color components, from NTSC grayscale equation.
  * The coefficients are multiplied by 100 and rounded towards nearest integer,
  * to facilitate integer math. The squared coefficients are also multiplied
  * by 100 and rounded to nearest integer (thus 173 == 1.73, 242 == 2.42 etc).
  */
-/// Red component sensivity
+/// Red component sensitivity
 #define R_COEF		173
-/// Green component sensivity
+/// Green component sensitivity
 #define G_COEF		242
-/// Blue component sensivity
+/// Blue component sensitivity
 #define B_COEF		107
 
 #endif // RGBPIXEL_H__

--- a/include/lensfun/lensfun.h.in
+++ b/include/lensfun/lensfun.h.in
@@ -77,7 +77,7 @@ extern "C" {
 #define LF_MAX_DATABASE_VERSION	2
 
 #if defined CONF_LENSFUN_STATIC
-/// This macro expands to an appropiate symbol visibility declaration
+/// This macro expands to an appropriate symbol visibility declaration
 #   define LF_EXPORT
 #else
 #   ifdef CONF_SYMBOL_VISIBILITY
@@ -127,7 +127,7 @@ typedef char *lfMLstr;
 /** liblensfun error codes: negative codes are -errno, positive are here */
 enum lfError
 {
-    /** No error occured */
+    /** No error occurred */
     LF_NO_ERROR = 0,
     /** Wrong XML data format */
     LF_WRONG_FORMAT,
@@ -213,7 +213,7 @@ LF_EXPORT lfMLstr lf_mlstr_dup (const lfMLstr str);
  * Objects of this type are usually retrieved from the database
  * by using queries (see lfDatabase::FindMount() / lf_db_find_mount()),
  * and can be created manually in which case it is application's
- * responsability to destroy the object when it is not needed anymore.
+ * responsibility to destroy the object when it is not needed anymore.
  */
 struct LF_EXPORT lfMount
 {
@@ -1773,7 +1773,7 @@ struct LF_EXPORT lfDatabase
       * @brief Open and parse all XML files in a given directory.
       *
       * Returns true if valid Lensfun XML data was found and loaded
-      * sucessfully.
+      * successfully.
       *
       * This function is deprecated and will be removed in the future.
       * Please use the lfDatabase::Load(const char *pathname) syntax instead.
@@ -1781,7 +1781,7 @@ struct LF_EXPORT lfDatabase
       * @param dirname
       *     The directory to be read.
       * @return
-      *     True if valid lensfun XML data was succesfully loaded.
+      *     True if valid lensfun XML data was successfully loaded.
       */
      DEPRECATED bool LoadDirectory (const char *dirname);
 
@@ -2839,12 +2839,12 @@ private:
      *     A opaque pointer to some data.
      * @param x
      *     The X coordinate of the beginning of the strip. For next pixels
-     *     the X coordinate increments sequentialy.
+     *     the X coordinate increments sequentially.
      * @param y
      *     The Y coordinate of the pixel strip. This is a constant across
      *     all pixels of the strip.
      * @param pixels
-     *     A pointer to pixel data. It is the responsability of the function
+     *     A pointer to pixel data. It is the responsibility of the function
      *     inserting the callback into the chain to provide a callback operating
      *     with the correct pixel format.
      * @param comp_role

--- a/libs/lensfun/database.cpp
+++ b/libs/lensfun/database.cpp
@@ -34,7 +34,7 @@ const char* const lfDatabase::SystemUpdatesLocation = g_build_filename (SYSTEM_D
 lfDatabase::lfDatabase ()
 {
 
-    // Take care to replace all occurences with the respective static variables
+    // Take care to replace all occurrences with the respective static variables
     // when the deprecated HomeDataDir and UserUpdatesDir variables are removed.
     HomeDataDir = strdup(lfDatabase::UserLocation);
     UserUpdatesDir = strdup(lfDatabase::UserUpdatesLocation);

--- a/libs/lensfun/lens.cpp
+++ b/libs/lensfun/lens.cpp
@@ -1164,7 +1164,7 @@ static float __vignetting_dist (
     const lfLens *l, const lfLensCalibVignetting &x, float focal, float aperture, float distance)
 {
     // translate every value to linear scale and normalize
-    // approximatively to range 0..1
+    // approximately to range 0..1
     float f1 = focal - l->MinFocal;
     float f2 = x.Focal - l->MinFocal;
     float df = l->MaxFocal - l->MinFocal;

--- a/libs/lensfun/lensfunprv.h
+++ b/libs/lensfun/lensfunprv.h
@@ -237,7 +237,7 @@ public:
      *     The string to match against.  This is typically taken from the
      *     Lensfun database.
      * @return
-     *     Returns a score in range 0-100.  If the match succedes, this score
+     *     Returns a score in range 0-100.  If the match succeeds, this score
      *     is the number of matched words divided by the mean word count of
      *     pattern and string, given as a percentage.  If it fails, it is 0.
      *     It fails if no words could be matched, of if allwords was set to
@@ -256,7 +256,7 @@ public:
      * @return
      *     Returns the maximal score in range 0-100.  For every component of
      *     the multi-language string, a score is computed: If the match
-     *     succedes, the score is the number of matched words divided by the
+     *     succeeds, the score is the number of matched words divided by the
      *     mean word count of pattern and string, given as a percentage.  If it
      *     fails, it is 0.  It fails if no words could be matched, of if
      *     allwords was set to true and one word in pattern could not be found

--- a/libs/lensfun/mod-coord.cpp
+++ b/libs/lensfun/mod-coord.cpp
@@ -534,7 +534,7 @@ bool lfModifier::ApplyGeometryDistortion (
         for (auto cb : CoordCallbacks)
             cb->callback (cb, res, width);
 
-        // Convert normalized coordinates back into natural coordiates
+        // Convert normalized coordinates back into natural coordinates
         for (i = 0; i < width; i++)
         {
             res [0] = (res [0] + CenterX) * NormUnScale;

--- a/libs/lensfun/mod-pc.cpp
+++ b/libs/lensfun/mod-pc.cpp
@@ -12,7 +12,7 @@
 
     The general algorithm is as follows: The original image (note that the
     sensor sees everything mirror-inverted, but this is annihilated by the
-    back-projection later) is positioned parallely to the x-y plane at z = -
+    back-projection later) is positioned parallelly to the x-y plane at z = -
     focal length.  Then, it is central-projected to the full sphere (radius
     equals focal length), so it gets positive z coordinates and can be viewed
     properly from the origin.
@@ -26,7 +26,7 @@
     Next, the intersection of the horizontal control line with the x-z plane is
     determined.  Its rectascension is called 90° - ρₕ.  So, the sphere is
     rotation around the y axis a second time, this time by ρₕ.  Now, the right
-    vanishing point truely is to the right.
+    vanishing point truly is to the right.
 
     The rotated image plane is central-projected back into the sensor plane at
     z = - focal length.  In general, it will be way off the center of the
@@ -36,7 +36,7 @@
     center of gravity of the control points instead.
 
     Finally, the scaling in the center of the image is kept constant.  One can
-    finetune with an additinal scaling, but this way, one has a good starting
+    finetune with an additional scaling, but this way, one has a good starting
     point.
 
     Note that in reality, this whole process is performed backwards because we
@@ -671,7 +671,7 @@ int lfModifier::EnablePerspectiveCorrection (float *x, float *y, int count, floa
         cd->callback = ModifyCoord_Perspective_Correction;
         cd->priority = 300;
 
-        /* The occurances of factors and denominators here avoid additional
+        /* The occurrences of factors and denominators here avoid additional
            operations in the inner loop of perspective_correction_callback. */
         cd->A [0][0] = A [0][0] * mapping_scale;
         cd->A [0][1] = A [0][1] * mapping_scale;
@@ -687,7 +687,7 @@ int lfModifier::EnablePerspectiveCorrection (float *x, float *y, int count, floa
         cd->priority = 700;
         A = inverse_matrix (A);
 
-        /* The occurances of factors and denominators here avoid additional
+        /* The occurrences of factors and denominators here avoid additional
            operations in the inner loop of perspective_correction_callback. */
         cd->A [0][0] = A [0][0];
         cd->A [0][1] = A [0][1];

--- a/libs/lensfun/mod-subpix.cpp
+++ b/libs/lensfun/mod-subpix.cpp
@@ -144,7 +144,7 @@ bool lfModifier::ApplySubpixelDistortion (
         for (auto cb : SubpixelCallbacks)
             cb->callback (cb, res, width);
 
-        // Convert normalized coordinates back into natural coordiates
+        // Convert normalized coordinates back into natural coordinates
         for (i = width * 3; i > 0; i--)
         {
             res [0] = (res [0] + CenterX) * NormUnScale;
@@ -184,7 +184,7 @@ bool lfModifier::ApplySubpixelGeometryDistortion (
         for (auto cb : SubpixelCallbacks)
             cb->callback (cb, res, width);
 
-        // Convert normalized coordinates back into natural coordiates
+        // Convert normalized coordinates back into natural coordinates
         for (i = width * 3; i > 0; i--)
         {
             res [0] = (res [0] + CenterX) * NormUnScale;

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,7 @@ The tests in this folder are implemented using the GLib test framework.
     https://developer.gnome.org/glib/2.42/glib-Testing.html
  
 When CMake is configured with `-DBUILD_TESTS=on` the tests are build. The 
-individual tests are stand-alone exceutables and can also be run in a 
+individual tests are stand-alone executables and can also be run in a 
 debugger or for example in `valgrind` for deeper analysis.
 By running the tool `ctest` in the build directory the tests are executed 
 and the results are summarized.

--- a/tests/deprecated/test_modifier_coord_tiny_image_old.cpp
+++ b/tests/deprecated/test_modifier_coord_tiny_image_old.cpp
@@ -1,4 +1,4 @@
-/* This checks for off-by-one errors which occure most clearly in extremely
+/* This checks for off-by-one errors which occur most clearly in extremely
  * small images. */
 
 #include <string>

--- a/tests/deprecated/test_modifier_old.cpp
+++ b/tests/deprecated/test_modifier_old.cpp
@@ -34,7 +34,7 @@ void mod_teardown(lfFixture *lfFix, gconstpointer data)
     delete lfFix->lens;
 }
 
-// test to verifiy that projection center is image center
+// test to verify that projection center is image center
 void test_mod_projection_center(lfFixture* lfFix, gconstpointer data)
 {
     float in[2]  = {0, 0};

--- a/tests/test_modifier.cpp
+++ b/tests/test_modifier.cpp
@@ -33,7 +33,7 @@ void mod_teardown(lfFixture *lfFix, gconstpointer data)
     delete lfFix->lens;
 }
 
-// test to verifiy that projection center is image center
+// test to verify that projection center is image center
 void test_mod_projection_center(lfFixture* lfFix, gconstpointer data)
 {
     float in[2]  = {0, 0};

--- a/tests/test_modifier_coord_tiny_image.cpp
+++ b/tests/test_modifier_coord_tiny_image.cpp
@@ -1,4 +1,4 @@
-/* This checks for off-by-one errors which occure most clearly in extremely
+/* This checks for off-by-one errors which occur most clearly in extremely
  * small images. */
 
 #include <locale.h>

--- a/tools/calibrate/calibrate.py
+++ b/tools/calibrate/calibrate.py
@@ -305,7 +305,7 @@ if __name__ == '__main__':
             if not missing_lens_model_warning_printed:
                 print(filename + ":")
                 print("""I couldn't detect the lens model name and assumed "Standard".
-For cameras without interchangable lenses, this may be correct.
+For cameras without interchangeable lenses, this may be correct.
 However, this fails if there is data of different undetectable lenses.
 A newer version of exiv2 (if available) may help.
 (This message is printed only once.)\n""")

--- a/tools/calibration_statistics/statistics.py
+++ b/tools/calibration_statistics/statistics.py
@@ -4,7 +4,7 @@
 statistics with them.  In particular, it makes plots and measures how well the
 data can be interpolated linerarly, in different coordinate systems.
 
-This scrips only looks at zoom lenses with at least 3 focal lengths.
+This script only looks at zoom lenses with at least 3 focal lengths.
 Otherwise, linear interpolation would be unnecessary or trivial.
 """
 

--- a/tools/calibration_webserver/README.rst
+++ b/tools/calibration_webserver/README.rst
@@ -17,7 +17,7 @@ Configuration
   unrar, 7zip, unzip, PyGithub, ImageMagick, Apache, and Python WSGI.
 * Adjust the settings in ``settings.py``.  This is an ordinary `Django
   settings`_ file.  Settings you should change are ``ALLOWED_HOSTS`` and
-  ``SECRET_KEY``.  (The ``SECRET_KEY`` is not used by this appication
+  ``SECRET_KEY``.  (The ``SECRET_KEY`` is not used by this application
   currently, but this may change in a later version, so set the ``SECRET_KEY``
   to a new value kanyway.)
 * Adjust the values in ``calibration_webserver.ini``.  This file must be moved

--- a/tools/calibration_webserver/calibration/templates/calibration/error.html
+++ b/tools/calibration_webserver/calibration/templates/calibration/error.html
@@ -1,9 +1,9 @@
 {% extends "calibration/base.html" %}
 
 {% block content %}
-<h1>An error occured …</h1>
+<h1>An error occurred …</h1>
 
-<p>The following error occured after your upload:</p>
+<p>The following error occurred after your upload:</p>
 
 <blockquote><em><pre>{{ error }}</pre></em></blockquote>
 

--- a/tools/calibration_webserver/calibration/templates/calibration/good_bad_ugly.html
+++ b/tools/calibration_webserver/calibration/templates/calibration/good_bad_ugly.html
@@ -10,7 +10,7 @@
      alt="Good anti-distortion picture"/>
 
 
-<p style="padding-top: 5ex">The good one: Two horizonal lines,
+<p style="padding-top: 5ex">The good one: Two horizontal lines,
 one <em>very</em> close to one of the long edges, the other one 1/3 from the
 top.  Note that tilting and rotating the camera is allowed, as well as changing
 the distance.</p>
@@ -20,7 +20,7 @@ the distance.</p>
 <img style="float: left; margin-right: 2em; margin-top: 1ex" src="{% static "calibration/images/no_long_line.jpg" %}"
      alt="Bad calibration picture"/>
 
-<p style="padding-top: 5ex">A bad one: The horizonal lines are in the proper
+<p style="padding-top: 5ex">A bad one: The horizontal lines are in the proper
 position (at the bottom, at least), but they are not running from one edge to
 the other.  I need lines covering the full width.</p>
 
@@ -30,7 +30,7 @@ the other.  I need lines covering the full width.</p>
      src="{% static "calibration/images/too_far_away.jpg" %}"
      alt="Bad calibration picture"/>
 
-<p style="padding-top: 5ex">Another bad one: All horizonal lines are too far
+<p style="padding-top: 5ex">Another bad one: All horizontal lines are too far
   away from the long edges.  Put one line insanely mind-bogglingly staggeringly
   close to the edge.</p>
 

--- a/tools/calibration_webserver/process_upload.py
+++ b/tools/calibration_webserver/process_upload.py
@@ -3,7 +3,7 @@
 """This script takes the location of a file archive (e.g. a tarball) as its
 argument and converts it into an extracted set of files in the same directory.
 Moreover, all image files are renamed so that the most important image
-parameters like the focal length are included into the filename.  Futhermore, a
+parameters like the focal length are included into the filename.  Furthermore, a
 GitHub issue is created in the “lensfun/lensfun” repository.  Finally, the
 ownCloud command line client is called for pushing the new files to the
 ownCloud server for the calibrators to pick them up.

--- a/tools/lenslist/show_lensfun_coverage.py
+++ b/tools/lenslist/show_lensfun_coverage.py
@@ -76,7 +76,7 @@ class Lens:
 # Main routine
 #----------------------------------------------------------------------
 
-# set up the commandline parser and define some arguemnts
+# set up the commandline parser and define some arguments
 parser = argparse.ArgumentParser(description='Create a list of all cameras and lenses in the Lensfun database.')
 parser.add_argument('db_path', metavar='DB_PATH', help='path to the Lensfun database', default='/usr/share/lensfun/', nargs='?')
 parser.add_argument('-g', dest='git', action='store_true', help='use current database from git repository')
@@ -87,7 +87,7 @@ parser.add_argument('-o', dest='outfile', action='store', help='output filename 
 cmdline_args = vars(parser.parse_args())
 
 
-# decide wether to get the most up to date database from git or use the locally installed database
+# decide whether to get the most up to date database from git or use the locally installed database
 if cmdline_args['git']==True:
     XmlDBPath = os.path.join(tempfile.gettempdir(), "lensfun")
     print("~ Lensfun database is retrieved directly from git")

--- a/tools/perspective_control/perspective_control.py
+++ b/tools/perspective_control/perspective_control.py
@@ -343,7 +343,7 @@ class Modifier:
 
     The general algorithm is as follows: The original image (note that the
     sensor sees everything mirror-inverted, but this is annihilated by the
-    back-projection later) is positioned parallely to the x-y plane at z = -
+    back-projection later) is positioned parallelly to the x-y plane at z = -
     focal length.  Then, it is central-projected to the full sphere (radius
     equals focal length), so it gets positive z coordinates and can be viewed
     properly from the origin.
@@ -357,7 +357,7 @@ class Modifier:
     Next, the intersection of the horizontal control line with the x-z plane is
     determined.  Its rectascension is called 90° - ρₕ.  So, the sphere is
     rotation around the y axis a second time, this time by ρₕ.  Now, the right
-    vanishing point truely is to the right.
+    vanishing point truly is to the right.
 
     The rotated image plane is central-projected back into the sensor plane at
     z = - focal length.  In general, it will be way off the center of the
@@ -367,7 +367,7 @@ class Modifier:
     center of gravity of the control points instead.
 
     Finally, the scaling in the center of the image is kept constant.  One can
-    finetune with an additinal scaling, but this way, one has a good starting
+    finetune with an additional scaling, but this way, one has a good starting
     point.
 
     Note that in reality, this whole process is performed backwards because we
@@ -454,10 +454,10 @@ class Modifier:
         elif d >= 1:
             d = 1
         # x, y = x[:4], y[:4]  # For testing only four points
-        # x[0:6] = x[0], x[2], x[1], x[3], x[0], x[1]  # For testing horizonal mode
-        # y[0:6] = y[0], y[2], y[1], y[3], y[0], y[1]  # For testing horizonal mode
-        # x[6:8] = [x[1], x[3]]  # for faking an explicit second horizonal line
-        # y[6:8] = [y[1], y[3]]  # for faking an explicit second horizonal line
+        # x[0:6] = x[0], x[2], x[1], x[3], x[0], x[1]  # For testing horizontal mode
+        # y[0:6] = y[0], y[2], y[1], y[3], y[0], y[1]  # For testing horizontal mode
+        # x[6:8] = [x[1], x[3]]  # for faking an explicit second horizontal line
+        # y[6:8] = [y[1], y[3]]  # for faking an explicit second horizontal line
         x = [value * self.norm_scale - self.center_x for value in x]
         y = [value * self.norm_scale - self.center_y for value in y]
 
@@ -503,7 +503,7 @@ class Modifier:
         Δa, Δb = central_projection(center_coords, f_normalized)
         Δa, Δb = cos(α) * Δa + sin(α) * Δb, - sin(α) * Δa + cos(α) * Δb
 
-        # The occurances of mapping_scale here avoid an additional
+        # The occurrences of mapping_scale here avoid an additional
         # multiplication in the inner loop of perspective_correction_callback.
         self.callback_data = A11 * mapping_scale, A12 * mapping_scale, A13, \
                              A21 * mapping_scale, A22 * mapping_scale, A23, \

--- a/tools/test_autoscale/test_autoscale.py
+++ b/tools/test_autoscale/test_autoscale.py
@@ -17,11 +17,11 @@ a corrected pincushion distortion pulls the corners most closely to the centre,
 so they need the maximal scaling.  On the other hand, a corrected barrel
 distorion leaves the edge centres most closely to the origin, so their position
 is critical.  In case of a nasty moustache distortion, the maximal scaling may
-be inbetween, and in these cases, Lensfun's approach fails.
+be in between, and in these cases, Lensfun's approach fails.
 
 This program shows for which lenses it fails, and how badly.  For
 non-rectilinear lenses, the projection is changed to rectilinear first.
-Currenly (as of April 2015), there is nothing to worry about.  Only three
+Currently (as of April 2015), there is nothing to worry about.  Only three
 lenses fail, and all of them exhibit only very slim black areas after the
 correction.  If one leaves the original projection, two fisheyes join the
 pack.

--- a/tools/testimage/testimage.py
+++ b/tools/testimage/testimage.py
@@ -29,7 +29,7 @@ The following things are particularly interesting to check:
 
     This is because this is the way they are calibrated: Vignetting is
     calibrated on a totally uncorrected image.  TCA is so, too, however, TCA
-    doesn't care about vignetting noticably.  Well, and then the image is
+    doesn't care about vignetting noticeably.  Well, and then the image is
     un-distorted.
 
     Note that Lensfun seems to work the other way round.  But this is only
@@ -42,7 +42,7 @@ The following things are particularly interesting to check:
    it must work nevertheless.
 
     If you have a sensor smaller than the one used for calibration, this
-    program testimage.py has an easy job: It just has to use the corresponsing
+    program testimage.py has an easy job: It just has to use the corresponding
     inner part of the resulting picture.
 
     However, for Lensfun, it is more difficult because it works on the
@@ -61,7 +61,7 @@ The following things are particularly interesting to check:
     is very large, e.g. 10 or 100, a correction is rejected because the
     to-be-corrected sensor is larger (much larger actually).  However, one can
     use at least convert from fisheye to rectilinear, where the cropfactor of
-    the calibration sensor should not matter.  Due to ``size - 1`` occurences
+    the calibration sensor should not matter.  Due to ``size - 1`` occurrences
     in modifier.cpp, strange things happened, because the ``size`` didn't refer
     to pixel size at this point.
 
@@ -91,7 +91,7 @@ parser.add_argument("--portrait", action="store_true",
 parser.add_argument("--outfile", default="testimage.tiff", help="Path to the output file.  Default: testimage.tiff")
 parser.add_argument("--db-path", help="Path to the database.  If not given, look in the same places as Lensfun.")
 parser.add_argument("--no-vignetting", dest="vignetting", action="store_false",
-                    help="Supresses simulation of vignetting.  *Much* faster.")
+                    help="Suppresses simulation of vignetting.  *Much* faster.")
 args = parser.parse_args()
 lens_model_name, camera_model_name, focal_length, aperture, distance = \
                                 args.lens_model_name, args.camera_model_name, args.focal_length, args.aperture, args.distance


### PR DESCRIPTION
Found via `codespell -q 3 -S *.svg,./ChangeLog,./sourceforge-archive,./berlios-archive -L ist,makro,nd,ois,optio`

Follow-up of #2060