### PR TITLE
install setuptools in cmake-windows workflow

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -22,6 +22,12 @@ jobs:
         vcpkg integrate install
     - name: Install xsltproc
       run: choco install xsltproc
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install setuptools
+      run: python -m pip install --upgrade pip setuptools
     - name: Build and Install using CMake
       run: |
         mkdir build


### PR DESCRIPTION
The CMake-Windows workflow currently fails with `ModuleNotFoundError: No module named 'setuptools'`. Fixed by installing the python package setuptools. Implemented as described [here](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#installing-dependencies).