### PR TITLE
replace "sourceforge.net" with "lensfun.github.io" in lensfun-update-data

### DIFF
--- a/.github/workflows/make-lenslist.yml
+++ b/.github/workflows/make-lenslist.yml
@@ -47,7 +47,9 @@ jobs:
         git add _posts/lenslist/2999-12-31-Lenslist-master.md
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
-        git commit -m "Update master lens list from GitHub Actions"
+        # A change without adding a new lens or camera doesn't change the lenslist and the commit would fail.
+        # With --allow-empty the commit succedes and the workflow for data hosting on lensfun/lensfun.github.io is triggered.
+        git commit --allow-empty -m "Update master lens list from GitHub Actions"
         git push https://$USERNAME:$REPO_KEY@github.com/lensfun/lensfun.github.io.git
       env:
         REPO_KEY: ${{secrets.PUSH_SECRET}}

--- a/apps/lensfun-update-data
+++ b/apps/lensfun-update-data
@@ -142,7 +142,7 @@ def read_location(base_url):
                     read_location(base_url)
 
 
-read_location("https://lensfun.sourceforge.net/db/")
+read_location("https://lensfun.github.io/db/")
 read_location("https://wilson.bronger.org/lensfun-db/")
 
 if not at_least_one_responsive_location:


### PR DESCRIPTION
The final part of https://github.com/lensfun/lensfun/issues/2131 (fixes #2131)

Only merge after https://github.com/lensfun/lensfun.github.io/pull/9!

Replaces the Sourceforge source with "lensfun.github.io" (https://github.com/lensfun/lensfun/issues/2131#issuecomment-1848921025)