### PR TITLE
Add further mounts to Sigma 100-400mm F5-6.3 DG OS HSM

### DIFF
--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -3832,6 +3832,9 @@
         <maker>Sigma</maker>
         <model>100-400mm F5-6.3 DG OS HSM | Contemporary 017</model>
         <model lang="en">100-400mm F5-6.3 DG OS HSM | C</model>
+        <mount>Canon EF</mount>
+        <mount>Sigma SA</mount>
+        <mount>Nikon F AF</mount>
         <mount>Sony E</mount>
         <cropfactor>1</cropfactor>
         <calibration>


### PR DESCRIPTION
The Sigma 100-400mm F5-6.3 DG OS HSM | Contemporary is also available for the "Canon EF", "Sigma SA" and "Nikon F AF" mounts.