### PR TITLE
Add C interface for EnableDistortionCorrection

### DIFF
--- a/include/lensfun/lensfun.h.in
+++ b/include/lensfun/lensfun.h.in
@@ -2715,6 +2715,9 @@ LF_EXPORT int lf_modifier_enable_scaling (lfModifier *modifier, float scale);
 /** @sa lfModifier::EnableDistortionCorrection */
 LF_EXPORT int lf_modifier_enable_distortion_correction (lfModifier *modifier);
 
+/** @sa lfModifier::EnableDistortionCorrection */
+LF_EXPORT int lf_modifier_enable_distortion_correction_lcd (lfModifier *modifier, const lfLensCalibDistortion* lcd);
+
 /** @sa lfModifier::EnableTCACorrection */
 LF_EXPORT int lf_modifier_enable_tca_correction (lfModifier *modifier);
 

--- a/libs/lensfun/mod-coord.cpp
+++ b/libs/lensfun/mod-coord.cpp
@@ -1243,6 +1243,11 @@ int lf_modifier_enable_distortion_correction (lfModifier *modifier)
     return modifier->EnableDistortionCorrection();
 }
 
+int lf_modifier_enable_distortion_correction_lcd (lfModifier *modifier, const lfLensCalibDistortion* lcd)
+{
+    return modifier->EnableDistortionCorrection(*lcd);
+}
+
 int lf_modifier_enable_projection_transform (
     lfModifier *modifier, lfLensType target_projection)
 {


### PR DESCRIPTION
Add C interface for `lfModifier::EnableDistortionCorrection (const lfLensCalibDistortion& lcd)`, addresses https://github.com/lensfun/lensfun/issues/502

I'm just a bit concerned about naming.