### PR TITLE
Add clang-tidy CI action

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,45 @@
+name: Clang-Tidy
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  check-needed:
+    runs-on: ubuntu-latest
+
+    outputs:
+      status: ${{ steps.needed.outcome }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Checkout base ref
+      run: git fetch origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}";
+    - name: Check if clang-tidy required
+      id: needed
+      continue-on-error: true
+      run: git diff --name-only -U0 "origin/${GITHUB_BASE_REF}" | grep -c -e "\.cpp$" -e "\.h\.in$" -e "\.h\.in\.cmake$" -e "\.h$" -e "\.hpp"
+    
+  run-tidy:
+    needs: check-needed
+    if: needs.check-needed.outputs.status == 'success'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Checkout base ref
+      run: git fetch origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}";
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_TESTS=ON -DBUILD_LENSTOOL=ON
+    - name: Install clang-tidy for clang-tidy-diff
+      run: sudo apt update && sudo apt install clang-tidy
+    - name: Run clang-tidy
+      run: git diff origin/${GITHUB_BASE_REF}..HEAD | clang-tidy-diff -use-color -p1 -regex .*cpp -path ${{github.workspace}}/build > out 2> err
+    - name: Check results
+      run: if grep -q "warnings treated as errors" err; then cat out; false; else true; fi

--- a/libs/lensfun/.clang-tidy
+++ b/libs/lensfun/.clang-tidy
@@ -1,0 +1,74 @@
+Checks: '-*,
+         clang-analyzer-*,
+         performance-*,
+
+         misc-*,
+         -misc-no-recursion,
+         -misc-non-private-member-variables-in-classes,
+
+         modernize-*,
+         -modernize-use-trailing-return-type,
+         -modernize-use-auto,
+
+         readability-*,
+         -readability-implicit-bool-conversion,
+         -readability-braces-around-statements,
+         -readability-identifier-length,
+         -readability-magic-numbers,
+         -readability-function-cognitive-complexity,
+         -readability-uppercase-literal-suffix,
+         -readability-simplify-boolean-expr,
+         -readability-else-after-return,
+         -readability-named-parameter,
+
+         cppcoreguidelines-*,
+         -cppcoreguidelines-avoid-magic-numbers,
+         -cppcoreguidelines-avoid-goto,
+         -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+         -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+         -cppcoreguidelines-pro-bounds-constant-array-index,
+         -cppcoreguidelines-pro-type-vararg,
+         -cppcoreguidelines-pro-type-union-access,
+         -cppcoreguidelines-narrowing-conversions,
+         -cppcoreguidelines-init-variables,
+         -cppcoreguidelines-non-private-member-variables-in-classes,
+
+
+
+         -clang-analyzer-security.insecureAPI.strcpy,
+         -clang-analyzer-core.NonNullParamChecker,
+
+         -misc-misplaced-const,
+
+         -modernize-use-nullptr,
+         -modernize-deprecated-headers,
+         -modernize-avoid-c-arrays,
+         -modernize-use-using,
+         -modernize-loop-convert,
+         -modernize-return-braced-init-list,
+         -modernize-use-equals-default,
+
+         -readability-inconsistent-declaration-parameter-name,
+         -readability-isolate-declaration,
+         -readability-non-const-parameter,
+         -readability-convert-member-functions-to-static,
+         -readability-make-member-function-const,
+         -readability-qualified-auto,
+         -readability-misleading-indentation,
+         -readability-container-size-empty,
+         -readability-simplify-subscript-expr,
+         -readability-avoid-const-params-in-decls,
+
+         -cppcoreguidelines-avoid-c-arrays,
+         -cppcoreguidelines-pro-type-cstyle-cast,
+         -cppcoreguidelines-pro-type-member-init,
+         -cppcoreguidelines-prefer-member-initializer,
+         -cppcoreguidelines-owning-memory,
+         -cppcoreguidelines-macro-usage,
+         -cppcoreguidelines-no-malloc,
+         -cppcoreguidelines-avoid-non-const-global-variables,
+         -cppcoreguidelines-special-member-functions,
+         '
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'lensfun.*\.h'
+AnalyzeTemporaryDtors: false

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,0 +1,62 @@
+Checks: '-*,
+         clang-analyzer-*,
+         performance-*,
+
+         misc-*,
+         -misc-no-recursion,
+         -misc-non-private-member-variables-in-classes,
+
+         modernize-*,
+         -modernize-use-trailing-return-type,
+         -modernize-use-auto,
+
+         readability-*,
+         -readability-implicit-bool-conversion,
+         -readability-braces-around-statements,
+         -readability-identifier-length,
+         -readability-magic-numbers,
+         -readability-function-cognitive-complexity,
+         -readability-uppercase-literal-suffix,
+         -readability-simplify-boolean-expr,
+         -readability-else-after-return,
+         -readability-named-parameter,
+
+         cppcoreguidelines-*,
+         -cppcoreguidelines-avoid-magic-numbers,
+         -cppcoreguidelines-avoid-goto,
+         -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+         -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+         -cppcoreguidelines-pro-bounds-constant-array-index,
+         -cppcoreguidelines-pro-type-vararg,
+         -cppcoreguidelines-pro-type-union-access,
+         -cppcoreguidelines-narrowing-conversions,
+         -cppcoreguidelines-init-variables,
+         -cppcoreguidelines-non-private-member-variables-in-classes,
+
+
+
+         -performance-type-promotion-in-math-fn,
+
+         -misc-definitions-in-headers,
+
+         -modernize-use-nullptr,
+         -modernize-deprecated-headers,
+         -modernize-avoid-c-arrays,
+         -modernize-use-using,
+         -modernize-loop-convert,
+
+         -readability-container-data-pointer,
+         -readability-isolate-declaration,
+         -readability-non-const-parameter,
+
+         -cppcoreguidelines-avoid-c-arrays,
+         -cppcoreguidelines-pro-type-cstyle-cast,
+         -cppcoreguidelines-pro-type-member-init,
+
+         -cppcoreguidelines-owning-memory,
+         -cppcoreguidelines-macro-usage,
+         -cppcoreguidelines-no-malloc,
+'
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'common_code.hpp'
+AnalyzeTemporaryDtors: false


### PR DESCRIPTION
Partially fixes #2168

It runs actual check only if there are .cpp\.h file changed and does the check only for the changed parts of the files.

By default it enables lots of checks with some exclusions
```
         misc-*,
         -misc-no-recursion,
         -misc-non-private-member-variables-in-classes,
         modernize-*,
         -modernize-use-trailing-return-type,
         -modernize-use-auto,
         readability-*,
         -readability-implicit-bool-conversion,
         -readability-braces-around-statements,
         -readability-identifier-length,
         -readability-magic-numbers,
         -readability-function-cognitive-complexity,
         -readability-uppercase-literal-suffix,
         -readability-simplify-boolean-expr,
         -readability-else-after-return,
         -readability-named-parameter,
         cppcoreguidelines-*,
         -cppcoreguidelines-avoid-magic-numbers,
         -cppcoreguidelines-avoid-goto,
         -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
         -cppcoreguidelines-pro-bounds-pointer-arithmetic,
         -cppcoreguidelines-pro-bounds-constant-array-index,
         -cppcoreguidelines-pro-type-vararg,
         -cppcoreguidelines-pro-type-union-access,
         -cppcoreguidelines-narrowing-conversions,
         -cppcoreguidelines-init-variables,
         -cppcoreguidelines-non-private-member-variables-in-classes,
```
and after the check+exclusions the exception come.
Exclusions should not be fixed I guess, exceptions must be. But it's just my point of view and the list and the order is a subject for discussions.