### PR TITLE
Remove leftovers from 891415295cc474dacfdecce611f243f0a5e91a34

### DIFF
--- a/libs/lensfun/mod-subpix.cpp
+++ b/libs/lensfun/mod-subpix.cpp
@@ -374,8 +374,6 @@ void lfModifier::ModifyCoord_TCA_ACM (void *data, float *iocoord, int count)
                       2 * (alpha4 * y + alpha5 * x);
         iocoord [0] = alpha0 * (x * common_term + alpha5 * ru2);
         iocoord [1] = alpha0 * (y * common_term + alpha4 * ru2);
-        iocoord [0] = iocoord [0];
-        iocoord [1] = iocoord [1];
 
         x = iocoord [4];
         y = iocoord [5];


### PR DESCRIPTION
The changes in https://github.com/lensfun/lensfun/commit/891415295cc474dacfdecce611f243f0a5e91a34?diff=unified&w=1#diff-2da355433b619dd585d289baab70c66579fae400daecccd29f09a186dde5606c were
```diff
-        iocoord [0] = (iocoord [0] + cddata->center_x) / cddata->coordinate_correction;
-        iocoord [1] = (iocoord [1] + cddata->center_y) / cddata->coordinate_correction;
+        iocoord [0] = iocoord [0];
+        iocoord [1] = iocoord [1];
```