### PR TITLE
Add vignetting data for Canon RF 28mm F2.8 STM

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -1452,6 +1452,17 @@
         <calibration>
 	    <!-- Taken with Canon EOS R -->
             <distortion model="ptlens" focal="28" a="0.023" b="-0.084" c="0.053"/>
+	    <!-- Taken with Canon EOS R5 -->    
+            <vignetting model="pa" focal="28.0" aperture="2.8" distance="0.23" k1="-0.4951420" k2="-0.3906210" k3="0.2923385" />
+            <vignetting model="pa" focal="28.0" aperture="2.8" distance="1000" k1="-0.8921010" k2="0.0292273" k3="0.1116005" />
+            <vignetting model="pa" focal="28.0" aperture="4.0" distance="0.23" k1="-0.1727157" k2="-0.3415538" k3="0.1089792" />
+            <vignetting model="pa" focal="28.0" aperture="4.0" distance="1000" k1="-0.3275299" k2="-0.4481468" k3="0.1929395" />
+            <vignetting model="pa" focal="28.0" aperture="5.6" distance="0.23" k1="-0.1837897" k2="-0.3065662" k3="0.1216333" />
+            <vignetting model="pa" focal="28.0" aperture="5.6" distance="1000" k1="-0.2796303" k2="-0.6496476" k3="0.4703002" />
+            <vignetting model="pa" focal="28.0" aperture="8.0" distance="0.23" k1="-0.1717430" k2="-0.3237168" k3="0.1318829" />
+            <vignetting model="pa" focal="28.0" aperture="8.0" distance="1000" k1="-0.2297146" k2="-0.8270957" k3="0.6304396" />
+            <vignetting model="pa" focal="28.0" aperture="22.0" distance="0.23" k1="-0.1899638" k2="-0.3073526" k3="0.1245736" />
+            <vignetting model="pa" focal="28.0" aperture="22.0" distance="1000" k1="-0.2482203" k2="-0.8283087" k3="0.6445991" />
         </calibration>
     </lens>
 


### PR DESCRIPTION
Created with a flatfield mask and diffusor:
[vignetting.pdf](https://github.com/user-attachments/files/16216623/vignetting.pdf)
