### PR TITLE
Update Sigma 35mm f1.4 Art identification

### DIFF
--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -2181,7 +2181,7 @@
 
     <lens>
         <maker>Sigma</maker>
-        <model>Sigma 35mm f/1.4 DG HSM</model>
+        <model>Sigma 35mm f/1.4 DG HSM | A</model>
         <mount>Nikon F AF</mount>
         <mount>Sigma SA</mount>
         <mount>Canon EF</mount>


### PR DESCRIPTION
exiv2 identifies this lens as "Sigma 35mm f/1.4 DG HSM | A" instead of "Sigma 35mm f/1.4 DG HSM"

```
$ exiv2 -pa --grep lens/i 20220129-IMG_2364.CR3
Exif.Photo.LensSpecification                 Rational    4  35mm
Exif.Photo.LensModel                         Ascii      27  35mm F1.4 DG HSM | Art 012
Exif.Photo.LensSerialNumber                  Ascii      11  0000000000
Exif.CanonCs.LensType                        Short       1  Sigma 35mm f/1.4 DG HSM | A
Exif.CanonCs.Lens                            Short       3  35.0 mm
Exif.CanonFi.RFLensType                      SShort      1  n/v
Exif.Canon.LensModel                         Ascii     138  35mm F1.4 DG HSM | Art 012
Exif.CanonLiOp.DigitalLensOptimizer          SLong       1  Aus
Exif.CanonLe.LensSerialNumber                Byte        5  0000000000
Exif.CanonAfC.USMLensElectronicMF            SLong       1  Nach AF aktivieren
Exif.CanonAfC.LensDriveWhenAFImpossible      SLong       1  Fokus-Suche fortsetzen
```