### PR TITLE
Non functional changes, textual clean-up of the lens database and 1 distortion improvement

### DIFF
--- a/data/db/mil-leica.xml
+++ b/data/db/mil-leica.xml
@@ -17,7 +17,7 @@
         <model>Leica SL (Typ 601)</model>
         <model lang="en">SL (Typ 601)</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -26,7 +26,7 @@
         <model>Leica SL2</model>
         <model lang="en">SL2</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -35,7 +35,7 @@
         <model>Leica SL2-S</model>
         <model lang="en">SL2-S</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -44,7 +44,7 @@
         <model>Leica SL3</model>
         <model lang="en">SL3</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -87,13 +87,15 @@
         <maker>Leica</maker>
         <model>Digilux 3</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
+        <aspect-ratio>4:3</aspect-ratio>
     </camera>
 
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Summicron TL 1:2 23 ASPH.</model>
+        <model lang="en">Summicron-TL 23mm f/2 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -116,6 +118,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Summilux-TL 1:1.4/35 ASPH.</model>
+        <model lang="en">Summilux-TL 35mm f/1.4 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -128,6 +131,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Elmarit-TL 1:2.8/18 ASPH.</model>
+        <model lang="en">Elmarit-TL 18mm f/2.8 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -140,8 +144,9 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Vario-Elmarit-SL 1:2.8/24-70 ASPH.</model>
+        <model lang="en">Vario-Elmarit-SL 24-70mm f/2.8 ASPH.</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken with Leica SL2-S -->
             <distortion model="ptlens" focal="24" a="0.0500956" b="-0.142289" c="0.0749745"/>
@@ -155,9 +160,10 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>APO-Summicron-SL 1:2/50 ASPH.</model>
+        <model>APO-SUMMICRON-SL 1:2/50 ASPH.</model>
+        <model lang="en">APO-Summicron-SL 50mm f/2 ASPH.</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
              <!-- Taken with Leica SL2-S -->
             <distortion model="ptlens" focal="50" a="-0.00560624" b="0.0126691" c="-0.00395041"/>
@@ -167,12 +173,13 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>APO-Summicron-SL 1:2/35 ASPH.</model>
+        <model>APO-SUMMICRON-SL 1:2/35 ASPH.</model>
+        <model lang="en">APO-Summicron-SL 35mm f/2 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken with Lumix DC-S5 -->
-            <distortion model="ptlens" focal="35.0" a="0.00301375" b="-0.00739283" c="-0.00204227" />
+            <distortion model="ptlens" focal="35.0" a="0.00441253" b="-0.0118086" c="0.00138859" />
             <tca model="poly3" focal="35.0" br="-0.0000534" vr="1.0001312" bb="0.0000270" vb="0.9999340" />
             <vignetting model="pa" focal="35.0" aperture="2.0" distance="10" k1="-0.7797127" k2="0.0595193" k3="0.0941395" />
             <vignetting model="pa" focal="35.0" aperture="2.0" distance="1000" k1="-0.7797127" k2="0.0595193" k3="0.0941395" />

--- a/data/db/mil-leica.xml
+++ b/data/db/mil-leica.xml
@@ -88,7 +88,6 @@
         <model>Digilux 3</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
-        <aspect-ratio>4:3</aspect-ratio>
     </camera>
 
     <lens>

--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -5,252 +5,252 @@
         <maker>Panasonic</maker>
         <model>DMC-G1</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF1</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GH1</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GM1</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GX1</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G2</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF2</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GH2</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G3</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF3</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GH3</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GH4</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GH5</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-    
+
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GH5M2</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-    
+
      <camera>
         <maker>Panasonic</maker>
         <model>DC-GH5S</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-	
+
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GH6</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GH7</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G5</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-G9</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-G9M2</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GX9</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GX7MK3</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-G100</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-	
+
     <camera>
         <maker>Panasonic</maker>
         <model>DC-G110</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF5</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G6</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF6</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G7</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF7</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GX7</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G70</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G10</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GM5</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GF8</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GX8</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-G80</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
@@ -258,7 +258,7 @@
         <maker>Panasonic</maker>
         <model>DMC-G81</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
@@ -266,126 +266,125 @@
         <maker>Panasonic</maker>
         <model>DMC-G85</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DMC-GX80</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
-        <!-- Alias for the DMC-GX80. -->
+        <!-- Alias for the DMC-GX80 -->
         <maker>Panasonic</maker>
         <model>DMC-GX85</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
-        <!-- The GX800 is also known as GX850 and GF9 in some regions. -->
+        <!-- The GX800 is also known as GX850 and GF9 in some regions -->
         <maker>Panasonic</maker>
         <model>DC-GX800</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-GX880</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-	
-    <!-- Added by ExpPhysU on 2020-12-12. -->	
-    <!-- Source: https://www.dpreview.com/reviews/buying-guide-best-cameras-under-1500/9  and my own camera DC-G91-->
+
+    <!-- Added by ExpPhysU on 2020-12-12 -->
+    <!-- Source: https://www.dpreview.com/reviews/buying-guide-best-cameras-under-1500/9  and my own camera DC-G91 -->
     <camera>
         <maker>Panasonic</maker>
         <model>DC-G90</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-    
-    <!-- Added by ExpPhysU on 2020-12-12. -->	
+
+    <!-- Added by ExpPhysU on 2020-12-12 -->
     <camera>
-	 <!-- Alias for the DC-G90. -->
-	 <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name-->
+        <!-- Alias for the DC-G90 -->
+        <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name -->
         <maker>Panasonic</maker>
         <model>DC-G91</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-    
-    <!-- Added by ExpPhysU on 2020-12-12. -->	
+
+    <!-- Added by ExpPhysU on 2020-12-12 -->
     <camera>
-	 <!-- Alias for the DC-G90. -->
-	 <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name-->
+        <!-- Alias for the DC-G90 -->
+        <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name -->
         <maker>Panasonic</maker>
         <model>DC-G95</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
-    
-    <!-- Added by ExpPhysU on 2020-12-12. -->	
+
+    <!-- Added by ExpPhysU on 2020-12-12 -->
     <camera>
-	 <!-- Alias for the DC-G90. -->
-	 <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name-->
+        <!-- Alias for the DC-G90 -->
+        <!-- The G90 is also known as G91, G95 and G99 in some regions. G91 is the European Name -->
         <maker>Panasonic</maker>
         <model>DC-G99</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
     </camera>
- 
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S1</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S1H</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
-    </camera>    
+        <cropfactor>1.0</cropfactor>
+    </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S1R</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S5</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S5M2</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S5M2X</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Panasonic</maker>
         <model>DC-S9</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <lens>
@@ -394,7 +393,7 @@
         <mount>Micro 4/3 System</mount>
         <focal value="14"/>
         <aperture min="2.5" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="14" model="ptlens" a="0.0115556" b="-0.0589829" c="0.000154452"/>
@@ -428,7 +427,7 @@
         <mount>Micro 4/3 System</mount>
         <focal value="14"/>
         <aperture min="2.5" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="14" model="ptlens" a="0.000389003" b="-0.0125969" c="-0.00230827"/>
@@ -462,7 +461,7 @@
         <mount>Micro 4/3 System</mount>
         <focal value="20"/>
         <aperture min="1.7" max="16"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="20" model="ptlens" a="0.00670602" b="-0.0381172" c="0.0065352"/>
@@ -497,7 +496,7 @@
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion model="ptlens" focal="14" a="0.02565" b="-0.08842" c="0.01461"/>
@@ -617,7 +616,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G Vario 12-60mm f/3.5-5.6 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Panasonic DMC-G80 -->
@@ -641,7 +640,7 @@
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="5.6"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="14" model="ptlens" a="0.0225278" b="-0.0802366" c="0.00964907"/>
@@ -727,7 +726,7 @@
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="14" model="ptlens" a="0.0179152" b="-0.045476" c="-0.00473275"/>
@@ -847,7 +846,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G Vario 14-45mm f/3.5-5.6 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="14" model="ptlens" a="0.025592" b="-0.090127" c="0.015798"/>
@@ -965,7 +964,7 @@
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="140"/>
         <aperture min="4" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="14" model="ptlens" a="0.00966207" b="-0.0543377" c="-0.00740716"/>
@@ -1156,7 +1155,7 @@
         <model>LEICA DG NOCTICRON 42.5/F1.2 </model>
         <model lang="en">Leica DG Nocticron 42.5mm f/1.2 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion model="ptlens" focal="43" a="0.00946" b="-0.02442" c="0.00801"/>
@@ -1182,7 +1181,7 @@
         <model>Lumix G Vario 45-200mm f/4.0-5.6 Mega OIS</model>
         <model lang="en">Lumix G Vario 45-200mm f/4.0-5.6 Mega OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion model="ptlens" focal="45" a="0" b="0" c="0"/>
@@ -1285,7 +1284,7 @@
         <model>Lumix G Vario 45-200mm f/4.0-5.6 II</model>
         <model lang="en">Lumix G Vario 45-200mm f/4.0-5.6 II power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion model="ptlens" focal="45" a="0" b="0" c="0"/>
@@ -1390,7 +1389,7 @@
         <mount>Micro 4/3 System</mount>
         <focal min="100" max="300"/>
         <aperture min="4" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="100" model="ptlens" a="-0.000115873" b="0.00367061" c="0.000486072"/>
@@ -1512,7 +1511,7 @@
         <model>LUMIX G VARIO 100-300/F4.0-5.6II</model>
         <model lang="en">Lumix G Vario 100-300mm F4-5.6 II Power O.I.S.</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion focal="100" model="ptlens" a="-0.000115873" b="0.00367061" c="0.000486072"/>
@@ -1632,7 +1631,7 @@
         <maker>Panasonic</maker>
         <model>Leica DG Summilux 25mm f/1.4 Asph.</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -1661,7 +1660,7 @@
         <maker>Panasonic</maker>
         <model>Leica DG Summilux 25mm f/1.4 II</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -1690,7 +1689,7 @@
         <model>LUMIX G VARIO 35-100/F2.8</model>
         <model lang="en">Lumix G X Vario 35-100mm f/2.8 Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -1702,14 +1701,14 @@
             <distortion model="poly3" focal="100" k1="-0.00245"/>
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Panasonic</maker>
         <model>LUMIX G VARIO 35-100/F2.8II</model>
         <!-- same optic as Lumix G VARIO 35-100/F2.8 -->
         <model lang="en">Lumix G X VARIO 35-100 mm f/2.8 II Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -1727,7 +1726,7 @@
         <model>Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
         <model lang="en">Lumix G X Vario 12-35mm f/2.8</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -1762,7 +1761,7 @@
         <model>Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
         <model lang="en">Lumix G X Vario 12-35mm f/2.8 II</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -1795,7 +1794,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G 20mm f/1.7 II Asph.</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with DMC-GX7 -->
@@ -1841,7 +1840,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G Vario 35-100mm f/4.0-5.6 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus E-PL7 -->
@@ -1918,7 +1917,7 @@
         <model>Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
         <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <calibration>
             <!-- Taken with DMC-GX7 -->
             <distortion focal="45" model="ptlens" a="-0.01139" b="0.04017" c="-0.04716"/>
@@ -2028,7 +2027,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G Vario 7-14mm f/4.0 Asph.</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus E-M1 -->
@@ -2049,7 +2048,7 @@
         <maker>Panasonic</maker>
         <model>Leica DG Macro-Elmarit 45mm f/2.8</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus E-M1 -->
@@ -2064,7 +2063,7 @@
         <model>Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>
         <model lang="en">Lumix G X Vario PZ 45-175mm f/4.0-5.6</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Panasonic GH2 -->
@@ -2085,7 +2084,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Leica DG Summilux 15mm f/1.7 Asph.</model>
+        <model>LEICA DG SUMMILUX 15/F1.7</model>
+        <model lang="en">Leica DG Summilux 15mm f/1.7 Asph.</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -2122,7 +2122,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G Vario 12-32mm f/3.5-5.6 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Panasonic DMC-GM1 -->
@@ -2192,7 +2192,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G 14mm f/2.5 II</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with DMC-GM5 -->
@@ -2221,7 +2221,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G 42.5mm f/1.7</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus E-PM2 -->
@@ -2235,7 +2235,7 @@
         <model>Lumix G Vario 14-140mm f/3.5-5.6</model>
         <model lang="en">Lumix G Vario 14-140mm f/3.5-5.6 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Panasonic DMC-GH4 -->
@@ -2327,7 +2327,7 @@
         <model>Lumix G Vario 14-140mm f/3.5-5.6 II</model>
         <model lang="en">Lumix G Vario 14-140mm f/3.5-5.6 Asph. II Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Panasonic DMC-GH4 -->
@@ -2417,7 +2417,7 @@
         <maker>Panasonic</maker>
         <model>Lumix G 25mm f/1.7 Asph.</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M5 -->
@@ -2559,7 +2559,7 @@
         <model>LEICA DG 8-18/F2.8-4.0</model>
         <model lang="en">Leica DG Vario-Elmarit 8-18mm f/2.8-4 Asph.</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion model="ptlens" focal="8" a="0.01817" b="-0.09703" c="0.06238"/>
@@ -2616,7 +2616,7 @@
         <model>LEICA DG 100-400/F4.0-6.3</model>
         <model lang="en">Leica DG Vario-Elmar 100-400mm f/4.0-6.3 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <distortion model="ptlens" focal="100" a="0.00284" b="-0.00387" c="0.01244"/>
@@ -2760,7 +2760,7 @@
         <mount>Micro 4/3 System</mount>
         <focal value="30"/>
         <aperture min="2.8" max="22"/>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with DMC-G6 -->
@@ -2783,8 +2783,9 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix S 20-60/F3.5-5.6</model>
+        <model lang="en">Lumix S 20-60mm f/3.5-5.6</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="20" a="0.02161" b="-0.03781" c="-0.08584"/>
             <distortion model="ptlens" focal="22" a="0.0167" b="-0.03241" c="-0.05843"/>
@@ -2862,7 +2863,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix S 70-300/F4.5-5.6</model>
+        <model>LUMIX S 70-300/F4.5-5.6</model>
+        <model lang="en">Lumix S 70-300mm f/4.5-5.6</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -2934,7 +2936,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix S 24/F1.8</model>
+        <model>LUMIX S 24/F1.8</model>
+        <model lang="en">Lumix S 24mm f/1.8</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -2957,7 +2960,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>LUMIX S 50/F1.8</model>
-        <model lang="en">Lumix S 50mm f1.8</model>
+        <model lang="en">Lumix S 50mm f/1.8</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -2988,10 +2991,11 @@
             <vignetting model="pa" focal="50.0" aperture="22.0" distance="1000" k1="-0.2248039" k2="-0.0059836" k3="0.0500266" />
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix S 85/F1.8</model>
+        <model>LUMIX S 85/F1.8</model>
+        <model lang="en">Lumix S 85mm f/1.8</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -3014,6 +3018,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Leica D Summilux 25mm F1.4 Asph.</model>
+        <model lang="en">Leica D Summilux 25mm f/1.4 Asph.</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <calibration>
@@ -3025,7 +3030,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>LEICA DG 50-200/F2.8-4.0</model>
-        <model lang="en">Leica DG Vario-Elmarit 50-200 mm F2.8-4 Asph OIS</model>
+        <model lang="en">Leica DG Vario-Elmarit 50-200 mm f/2.8-4 Asph. OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -3048,7 +3053,7 @@
         <maker>Panasonic</maker>
         <model>Leica D Vario-Elmar 14-150mm f/3.5-5.6 Asph. OIS</model>
         <mount>4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
             <!-- Taken with Olympus OMD E-M1 -->
@@ -3068,12 +3073,12 @@
     <lens>
         <maker>Panasonic</maker>
         <model>LEICA DG SUMMILUX 9/F1.7</model>
-	<model lang="en">Leica DG Summilux 9mm f/1.7</model>
+        <model lang="en">Leica DG Summilux 9mm f/1.7</model>
         <mount>Micro 4/3 System</mount>
-        <cropfactor>2</cropfactor>
+        <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
-	    <!-- Taken with DMC-GX8 -->
+            <!-- Taken with DMC-GX8 -->
             <distortion model="ptlens" focal="9" a="0.02807" b="-0.09826" c="0.02753"/>
             <tca model="poly3" focal="9" vr="1.0002079" vb="1.0002006"/>
         </calibration>
@@ -3082,8 +3087,9 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix S 16-35/F4</model>
+        <model lang="en">Lumix S Pro 16-35mm f/4</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
              <!-- Taken with Leica SL2 -->
             <distortion model="ptlens" focal="16" a="0.020567" b="-0.0595563" c="-0.0351097"/>
@@ -3102,8 +3108,9 @@
    <lens>
         <maker>Panasonic</maker>
         <model>Lumix S 35/F1.8</model>
+        <model lang="en">Lumix S 35mm f/1.8</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken with Lumix DC-S5 -->
             <distortion model="ptlens" focal="35" a="-0.00601722" b="-0.0163318" c="0.00755225"/>

--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -6,15 +6,15 @@
         <model>Sigma fp</model>
         <model lang="en">fp</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
-    
+
     <camera>
         <maker>Sigma</maker>
         <model>Sigma fp L</model>
         <model lang="en">fp L</model>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -104,7 +104,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>Sigma 56mm F1.4 DC DN | Contemporary 018</model>
-        <model lang="en">Sigma 56 mm F1.4 DC DN | C 018</model>
+        <model lang="en">Sigma 56mm f/1.4 DC DN | C 018</model>
         <mount>Sony E</mount>
         <mount>Fujifilm X</mount>
         <mount>Leica L</mount>
@@ -166,7 +166,7 @@
     </lens>
 
     <lens>
-        <!-- Identifies itself at Sony cameras as “E 60mm F2.8”. -->
+        <!-- Identifies itself at Sony cameras as “E 60mm F2.8” -->
         <maker>Sigma</maker>
         <model>Sigma 60mm f/2.8 DN</model>
         <mount>Sony E</mount>
@@ -208,7 +208,7 @@
     </lens>
 
     <lens>
-        <!-- Identifies itself at Sony cameras as “E 19mm F2.8”. -->
+        <!-- Identifies itself at Sony cameras as “E 19mm F2.8” -->
         <maker>Sigma</maker>
         <model>Sigma 19mm f/2.8 DN</model>
         <mount>Sony E</mount>
@@ -268,7 +268,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>SIGMA 30mm f/1.4 DC DN | Contemporary C 016</model>
-        <model lang="en">30mm f/1.4 DC DN</model>
+        <model lang="en">Sigma 30mm f/1.4 DC DN</model>
         <mount>Sony E</mount>
         <mount>Micro 4/3 System</mount>
         <mount>Nikon Z</mount>
@@ -297,7 +297,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>Sigma 16mm f/1.4 DC DN | Contemporary C 017</model>
-        <model lang="en">Sigma 16mm f/1.4 DC DN C</model>
+        <model lang="en">Sigma 16mm f/1.4 DC DN Contemporary 017</model>
         <mount>Micro 4/3 System</mount>
         <mount>Sony E</mount>
         <cropfactor>2</cropfactor>
@@ -312,7 +312,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>Sigma 16mm f/1.4 DC DN | Contemporary 017</model>
-        <model lang="en">Sigma 16mm f/1.4 DC DN Contemporary</model>
+        <model lang="en">Sigma 16mm f/1.4 DC DN Contemporary 017</model>
         <mount>Micro 4/3 System</mount>
         <mount>Sony E</mount>
         <mount>Fujifilm X</mount>
@@ -352,17 +352,17 @@
             <vignetting model="pa" focal="16.0" aperture="16.0" distance="1000" k1="-0.3579104" k2="-0.0124186" k3="0.0314276"/>
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Sigma</maker>
         <model>105mm F1.4 DG HSM | Art 018</model>
-        <model lang="en">Sigma 105 mm F1.4 DG HSM Art</model>
+        <model lang="en">Sigma 105mm f/1.4 DG HSM Art 018</model>
         <mount>Sony E</mount>
         <mount>Canon EF</mount>
         <mount>Leica L</mount>
         <mount>Nikon F AF</mount>
         <mount>Sigma SA</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="105" a="0.0014406142874951258" b="-0.00614583454138938" c="0.0127487278055209"/>
             <tca model="poly3" focal="105" vr="0.9999963" vb="1.0000321"/>
@@ -410,12 +410,12 @@
             <vignetting model="pa" focal="105" aperture="16" distance="1000" k1="-0.1649" k2="-0.1053" k3="0.0771"/>
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Sigma</maker>
         <model>35mm F1.2 DG DN | Art 019</model>
         <mount>Sony E</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="35" a="-0.00036252595632404257" b="-0.010365850618003318" c="0.00024978328908901364"/>
             <tca model="poly3" focal="35" vr="1.0000559" vb="1.0000748"/>
@@ -493,13 +493,13 @@
             <vignetting model="pa" focal="35" aperture="16" distance="1000" k1="-0.4839" k2="0.0012" k3="0.0945"/>
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Sigma</maker>
         <model>14-24mm F2.8 DG DN | Art 019</model>
         <mount>Sony E</mount>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="14" a="0.0494500274128515" b="-0.176286257666241" c="0.158087525693153"/>
             <distortion model="ptlens" focal="14.6" a="0.024836080969686855" b="-0.0822062660046383" c="0.04972960282491836"/>
@@ -586,7 +586,7 @@
         <model>85mm F1.4 DG DN | Art 020</model>
         <mount>Sony E</mount>
         <mount>Leica L</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="85.0" a="0.008" b="-0.01" c="0.018" />
             <tca model="poly3" focal="85.0" br="-0.0000417" vr="1.0001211" bb="0.0000458" vb="0.9999134" />
@@ -783,7 +783,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>40mm F1.4 DG HSM | Art 018</model>
-        <model lang="en">Sigma 40mm F1.4 DG HSM | Art</model>
+        <model lang="en">Sigma 40mm f/1.4 DG HSM | Art</model>
         <mount>Canon EF</mount>
         <mount>Leica L</mount>
         <mount>Sony E</mount>
@@ -805,7 +805,7 @@
             <vignetting model="pa" focal="40.0" aperture="16.0" distance="1000" k1="-0.2878019" k2="0.0453093" k3="0.0104123"/>
         </calibration>
     </lens>
-   
+
    <lens>
         <maker>Sigma</maker>
         <model>20mm F2 DG DN | Contemporary 022</model>
@@ -818,7 +818,7 @@
             <tca model="poly3" focal="20" vr="1.0003052" cr="-0.0000000" br="0.0000000" vb="1.0000539" cb="-0.0000762" bb="0.0000259" />
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Sigma</maker>
         <model>24mm F2 DG DN | Contemporary 021</model>
@@ -880,10 +880,11 @@
             <tca model="poly3" focal="65" vr="1.0003439" cr="-0.0001381" br="0.0000462" vb="0.9998513" cb="-0.0000247" bb="0.0000400" />
         </calibration>
     </lens>
-    
+
     <lens>
         <maker>Sigma</maker>
         <model>90mm F2.8 DG DN | Contemporary 021</model>
+        <model lang="en">Sigma 90mm f/2.8 DG DN | Contemporary 021</model>
         <mount>Leica L</mount>
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
@@ -990,6 +991,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>24mm F3.5 DG DN | Contemporary 021</model>
+        <model lang="en">Sigma 45mm f/3.5 DG DN | Contemporary 021</model>
         <mount>Leica L</mount>
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
@@ -1021,13 +1023,13 @@
     <lens>
         <maker>Sigma</maker>
         <model>Sigma 28mm F1.4 DG HSM | A</model>
-        <model lang="en">28mm F1,4 DG HSM | Art</model>
+        <model lang="en">Sigma 28mm f/1.4 DG HSM | Art</model>
         <mount>Nikon F AF</mount>
         <mount>Leica L</mount>
         <mount>Sony E</mount>
         <mount>Canon EF</mount>
         <mount>Sigma SA</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
              <!-- Taken with Canon EOS 5DS R -->
             <distortion model="ptlens" focal="28" a="0.0047621" b="-0.0229217" c="0.0233745"/>
@@ -1051,7 +1053,7 @@
      <lens>
         <maker>Sigma</maker>
         <model>Sigma 28mm F1.4 DG HSM | A</model>
-        <model lang="en">28mm F1,4 DG HSM | Art</model>
+        <model lang="en">Sigma 28mm f/1.4 DG HSM | Art</model>
         <mount>Nikon F AF</mount>
         <mount>Leica L</mount>
         <mount>Sony E</mount>
@@ -1078,6 +1080,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>17mm F4 DG DN | Contemporary 023</model>
+        <model lang="en">Sigma 17mm f/4 DG DN | Contemporary 023</model>
         <mount>Leica L</mount>
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>

--- a/data/db/rf-leica.xml
+++ b/data/db/rf-leica.xml
@@ -16,7 +16,7 @@
         <model>Leica M (Typ 240)</model>
         <model lang="en">M (Typ 240)</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -25,23 +25,25 @@
         <model>Leica M Monochrom (Typ 246)</model>
         <model lang="en">M Monochrom (Typ 246)</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>M8 Digital Camera</model>
+        <model lang="en">M8</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>M9 Digital Camera</model>
+        <model lang="en">M9</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -50,7 +52,7 @@
         <model>Leica M10</model>
         <model lang="en">M10</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -59,7 +61,7 @@
         <model>Leica M10 Monochrom</model>
         <model lang="en">M10 Monochrom</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -68,7 +70,7 @@
         <model>Leica M10-D</model>
         <model lang="en">M10-D</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -77,7 +79,7 @@
         <model>Leica M10-P</model>
         <model lang="en">M10-P</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -86,7 +88,7 @@
         <model>Leica M10-R</model>
         <model lang="en">M10-R</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -95,7 +97,7 @@
         <model>Leica M11</model>
         <model lang="en">M11</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -104,7 +106,7 @@
         <model>Leica M11 Monochrom</model>
         <model lang="en">M11 Monochrom</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -113,7 +115,7 @@
         <model>Leica M11-P</model>
         <model lang="en">M11-P</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <camera>
@@ -122,18 +124,18 @@
         <model>Leica M11-D</model>
         <model lang="en">M11-D</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
     </camera>
 
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Elmarit-M 1:2.8/28 ASPH.</model>
-        <model lang="en">Elmarit-M 28mm f/2.8 ASPH</model>
+        <model lang="en">Elmarit-M 28mm f/2.8 ASPH.</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with LEICA M (Typ 240) -->
+            <!-- Taken with Leica M (Typ 240) -->
             <distortion model="ptlens" focal="28" a="0.00349" b="-0.00508" c="-0.01721"/>
         </calibration>
     </lens>
@@ -144,7 +146,7 @@
         <model>Elmarit-M 1:2.8/90</model>
         <model lang="en">Elmarit-M 90mm f/2.8</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken with Leica M (Typ 240) -->
             <distortion model="ptlens" focal="90" a="-0.00423" b="0.01406" c="-0.00692"/>
@@ -158,7 +160,7 @@
         <!-- Model 11819/11825/11826/11816 -->
         <model lang="en">Summicron-M 50mm f/2</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken Leica M (Typ 240) -->
             <distortion model="poly3" focal="50" k1="-0.00072"/>
@@ -171,7 +173,7 @@
         <maker lang="en">Leica</maker>
         <model>Summicron-M 1:2/28 ASPH.</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.0</cropfactor>
         <calibration>
             <!-- Taken with Leica M9 Digital Camera -->
             <distortion model="ptlens" focal="28" a="0.0135748" b="-0.0502846" c="0.0486119"/>


### PR DESCRIPTION
Improve lens pretty-names

Remove redundant spaces and redundant punctuation

Edit `<model>` tag to have literal exiftag as reported by exiv2: `<model> [model as reported by exiv2] </model>`

Make notation for `<cropfactor>` constistent, e.g. 1.0, 2.0

Added tag line for pretty name, formatted cf. many Lensfun database entries: `<model lang="en"> [pretty name] </model>`

Functional change:

Improve distortion params for Leica APO-Summicron-SL 35 (I am the original uploader of this correction)