### PR TITLE
Add camera Ricoh GR III HDF

### DIFF
--- a/data/db/compact-ricoh.xml
+++ b/data/db/compact-ricoh.xml
@@ -49,6 +49,15 @@
     <camera>
         <maker>Ricoh Imaging Company, Ltd.</maker>
         <maker lang="en">Ricoh</maker>
+        <model>Ricoh GR III HDF</model>
+        <model lang="en">GR III HDF</model>
+        <mount>ricohGRIII</mount>
+        <cropfactor>1.53</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Ricoh Imaging Company, Ltd.</maker>
+        <maker lang="en">Ricoh</maker>
         <model>Ricoh GR IIIx</model>
         <model lang="en">GR IIIx</model>
         <mount>ricohGRIIIx</mount>


### PR DESCRIPTION
Ricoh GR III HDF is same as Ricoh GR III with different built-in filter. The EXIF camera model has the HDF string.