### PR TITLE
Make Sigma 18-50mm f/2.8 DC DN Contemporary 021 usable on Fujifilm X

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -638,8 +638,10 @@
     <lens>
         <maker>Sigma</maker>
         <model>18-50mm F2.8 DC DN | Contemporary 021</model>
+        <model lang="en">Sigma 18-50mm F2.8 DC DN | Contemporary 021</model>
         <mount>Sony E</mount>
         <mount>Leica L</mount>
+        <mount>Fujifilm X</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="18" a="0.02179" b="-0.06976" c="0.00503"/>


### PR DESCRIPTION
I had to add a model alias because the EXIF data from the Fujifilm X-T4 reports this lens as "SIGMA 18-50mm F2.8 DC DN | Contemporary 021" which wouldn't match the other name apparently.

I'm not sure I'm doing the right thing here or which additional testing is required to ensure this is actually correct. I made a rough test with darktable and it looks as if it at least improves the situation compared to using EXIF-embedded lens data (left is lens correction w/ lensfun with this patch, right is using "embedded metadata"):

![ca](https://github.com/user-attachments/assets/d842f0f1-e694-46e0-b396-4213e6f003c7)
