### PR TITLE
Fix building on Windows ARM64 platforms

### DIFF
--- a/libs/lensfun/cpuid.cpp
+++ b/libs/lensfun/cpuid.cpp
@@ -7,7 +7,7 @@
 #include "lensfun.h"
 #include "lensfunprv.h"
 
-#if defined (_MSC_VER)
+#if defined (_MSC_VER) && !defined(_M_ARM64)
 #include <intrin.h>
 guint _lf_detect_cpu_features ()
 {


### PR DESCRIPTION
As Windows ARM64 does not have the CPUID instruction, the bit of code using it needs to be switched off.

The places the function is called (mod-color and mo-coord) have proper guards behind `VECTORIZATION_SSE` meaning there won't be any linker errors with this switched off - just the function definition itself didn't have a guard.

If desired, I could alternatively switch this patch to check for `defined(VECTORIZATION_SSE) || defined (VECTORIZATION_SSE2` instead of `_M_ARM64`.