### PR TITLE
Add Panasonic DMC-G8

### DIFF
--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -277,6 +277,14 @@
     </camera>
 
     <camera>
+        <!-- This is an alias for the DMC-G80 -->
+        <maker>Panasonic</maker>
+        <model>DMC-G8</model>
+        <mount>Micro 4/3 System</mount>
+        <cropfactor>2</cropfactor>
+    </camera>
+
+    <camera>
         <maker>Panasonic</maker>
         <model>DMC-GX80</model>
         <mount>Micro 4/3 System</mount>


### PR DESCRIPTION
Add the missing camera, which was released in 2016.