### PR TITLE
Add filter to TarFile.extract()

### DIFF
--- a/apps/lensfun-update-data
+++ b/apps/lensfun-update-data
@@ -92,7 +92,7 @@ class Location:
     def extract(self, directory):
         tar = tarfile.open(fileobj=urllib.request.urlopen(self.base_url + "version_{}.tar.bz2".format(self.version)),
                            mode="r|*")
-        tar.extractall(directory)
+        tar.extractall(directory,filter='data')
         tar.close()
 
 


### PR DESCRIPTION
Add `filter='data'` to TarFile extract for security and as required since Python 3.14.