### PR TITLE
Add model in E ... format for Tamron A058

### DIFF
--- a/data/db/mil-tamron.xml
+++ b/data/db/mil-tamron.xml
@@ -730,6 +730,7 @@
     <lens>
         <maker>Tamron</maker>
         <model>TAMRON 35-150mm F/2-2.8 Di III VXD A058Z</model>
+        <model>E 35-150mm F2.0-F2.8 A058</model>
         <model lang="en">Tamron 35-150mm F/2-2.8 Di III VXD</model>
         <mount>Nikon Z</mount>
         <mount>Sony E</mount>

--- a/data/db/mil-tamron.xml
+++ b/data/db/mil-tamron.xml
@@ -729,8 +729,7 @@
 
     <lens>
         <maker>Tamron</maker>
-        <model>TAMRON 35-150mm F/2-2.8 Di III VXD A058Z</model>
-        <model>E 35-150mm F2.0-F2.8 A058</model>
+        <model>Tamron E 35-150mm f/2-2.8 2.0-2.8 Di III VXD A058Z</model>
         <model lang="en">Tamron 35-150mm F/2-2.8 Di III VXD</model>
         <mount>Nikon Z</mount>
         <mount>Sony E</mount>


### PR DESCRIPTION
Metadata from my Sony A7iii for the Tamron 35-150 (A058) was picked up according to a format that exists for other Tamron lenses in the XML, but not yet for the A058. This PR fixes that detection (by Darktable, that is).

Edit: fixed branch name error..