### PR TITLE
Prettyfy display names leica

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -193,6 +193,14 @@
 
     <camera>
         <maker>Canon</maker>
+        <model>Canon EOS R5 C</model>
+        <model lang="en">EOS R5 C</model>
+        <mount>Canon RF</mount>
+        <cropfactor>1</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Canon</maker>
         <model>Canon EOS R5m2</model>
         <model lang="en">EOS R5 Mark II</model>
         <mount>Canon RF</mount>

--- a/data/db/mil-leica.xml
+++ b/data/db/mil-leica.xml
@@ -103,6 +103,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Summicron TL 1:2 23 ASPH.</model>
+        <model lang="en">Summicron-TL 23mm f/2 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -125,6 +126,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Summilux-TL 1:1.4/35 ASPH.</model>
+        <model lang="en">Summilux-TL 35mm f/1.4 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -137,6 +139,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Elmarit-TL 1:2.8/18 ASPH.</model>
+        <model lang="en">Elmarit-TL 18mm f/2.8 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -149,6 +152,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Vario-Elmarit-SL 1:2.8/24-70 ASPH.</model>
+        <model lang="en">Vario-Elmarit-SL 24-70mm f/2.8 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -165,6 +169,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>APO-Summicron-SL 1:2/50 ASPH.</model>
+        <model lang="en">APO-Summicron-SL 50mm f/2 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -177,6 +182,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>APO-Summicron-SL 1:2/35 ASPH.</model>
+        <model lang="en">APO-Summicron-SL 35mm f/2 ASPH.</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>

--- a/data/db/rf-leica.xml
+++ b/data/db/rf-leica.xml
@@ -170,6 +170,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Summicron-M 1:2/28 ASPH.</model>
+        <model lang="en">Summicron-M 28mm f/2</model>
         <mount>Leica M</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -183,7 +184,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Summicron M 1:2/35mm ASPH.</model>
-        <model lang="en">Summicron M 1:2/35mm ASPH. (11879/11882)</model>
+        <model lang="en">Summicron-M 35mm f/2 ASPH. (11879/11882)</model>
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -197,7 +198,7 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Apo-Summicron-M 1:2/75mm ASPH.</model>
-        <model lang="en">Apo-Summicron M 1:2/75mm ASPH.(11673/11701)</model>
+        <model lang="en">APO-Summicron-M 75mm f/2 ASPH.(11673/11701)</model>
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>

--- a/data/db/rf-leica.xml
+++ b/data/db/rf-leica.xml
@@ -33,7 +33,7 @@
         <maker lang="en">Leica</maker>
         <model>M8 Digital Camera</model>
         <mount>Leica M</mount>
-        <cropfactor>1</cropfactor>
+        <cropfactor>1.33</cropfactor>
     </camera>
 
     <camera>


### PR DESCRIPTION
As discussed/proposed in https://github.com/lensfun/lensfun/discussions/2523
This PR does
```
    NOT TOUCH the <model>string</model> line
    prettify some <model lang="en">string</model> lines

```
E.g.

- `<model>APO-Summicron-SL 1:2/35 ASPH.</model>` is literal as reported by exiv2, and is how Leica refers to the lens. However, look for instance at the Leica Store website (Amsterdam, https://www.leicastoreamsterdam.nl/copy-of-leica-apo-summicron-sl-35-f-2-asph-black.html) where they use a different format
- `<model lang="en">APO-Summicron-SL 35mm f/2 ASPH.</model>` is prettified