### PR TITLE
Prettify mil-nikon.xml

### DIFF
--- a/data/db/mil-nikon.xml
+++ b/data/db/mil-nikon.xml
@@ -385,7 +385,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z MC 50mm f/2.8</model>
+        <model>Nikkor Z MC 50mm f/2.8</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -407,7 +407,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 14-24mm f/2.8 S</model>
+        <model>Nikkor Z 14-24mm f/2.8 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -477,7 +477,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 14-30mm f/4 S</model>
+        <model>Nikkor Z 14-30mm f/4 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -554,7 +554,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 24-70mm f/2.8 S</model>
+        <model>Nikkor Z 24-70mm f/2.8 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -624,7 +624,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 24-70mm f/4 S</model>
+        <model>Nikkor Z 24-70mm f/4 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -694,7 +694,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 20mm f/1.8 S</model>
+        <model>Nikkor Z 20mm f/1.8 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -724,7 +724,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 50mm f/1.8 S</model>
+        <model>Nikkor Z 50mm f/1.8 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -750,7 +750,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 70-200mm f/2.8 VR S</model>
+        <model>Nikkor Z 70-200mm f/2.8 VR S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -823,7 +823,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 85mm f/1.8 S</model>
+        <model>Nikkor Z 85mm f/1.8 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -849,7 +849,7 @@
 	
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 24-200mm f/4-6.3 VR</model>
+        <model>Nikkor Z 24-200mm f/4-6.3 VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -941,7 +941,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z DX 16-50mm f/3.5-6.3 VR</model>
+        <model>Nikkor Z DX 16-50mm f/3.5-6.3 VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.531</cropfactor>
         <calibration>
@@ -965,7 +965,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 35mm f/1.8 S</model>
+        <model>Nikkor Z 35mm f/1.8 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -998,7 +998,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 40mm f/2</model>
+        <model>Nikkor Z 40mm f/2</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -1025,7 +1025,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z MC 105mm f/2.8 VR S</model>
+        <model>Nikkor Z MC 105mm f/2.8 VR S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1047,7 +1047,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 28-75mm f/2.8</model>
+        <model>Nikkor Z 28-75mm f/2.8</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1063,7 +1063,7 @@
 
      <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 24-120mm f/4 S</model>
+        <model>Nikkor Z 24-120mm f/4 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1171,7 +1171,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 100-400mm f/4.5-5.6 VR S</model>
+        <model>Nikkor Z 100-400mm f/4.5-5.6 VR S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -1267,7 +1267,7 @@
 	
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 50mm f/1.2 S</model>
+        <model>Nikkor Z 50mm f/1.2 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -1298,7 +1298,7 @@
     </lens>
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z DX 50-250mm f/4.5-6.3 VR</model>
+        <model>Nikkor Z DX 50-250mm f/4.5-6.3 VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.5</cropfactor>
         <calibration>
@@ -1373,7 +1373,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 28mm f/2.8</model>
+        <model>Nikkor Z 28mm f/2.8</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1398,7 +1398,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 135mm f/1.8 S Plena</model>
+        <model>Nikkor Z 135mm f/1.8 S Plena</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1430,7 +1430,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 85mm f/1.2 S</model>
+        <model>Nikkor Z 85mm f/1.2 S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -1462,7 +1462,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 600mm f/6.3 VR S</model>
+        <model>Nikkor Z 600mm f/6.3 VR S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1485,7 +1485,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 26mm f/2.8</model>
+        <model>Nikkor Z 26mm f/2.8</model>
         <mount>Nikon Z</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -1509,7 +1509,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z DX 12-28mm f/3.5-5.6 PZ VR</model>
+        <model>Nikkor Z DX 12-28mm f/3.5-5.6 PZ VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.531</cropfactor>
         <calibration>
@@ -1570,7 +1570,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 28-400mm f/4-8 VR</model>
+        <model>Nikkor Z 28-400mm f/4-8 VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1596,7 +1596,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 180-600mm f/5.6-6.3 VR</model>
+        <model>Nikkor Z 180-600mm f/5.6-6.3 VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1692,7 +1692,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 35mm f/1.4</model>
+        <model>Nikkor Z 35mm f/1.4</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1704,7 +1704,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z DX 18-140mm f/3.5-6.3 VR</model>
+        <model>Nikkor Z DX 18-140mm f/3.5-6.3 VR</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.531</cropfactor>
         <calibration>
@@ -1721,7 +1721,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z DX 24mm f/1.7</model>
+        <model>Nikkor Z DX 24mm f/1.7</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.531</cropfactor>
         <calibration>
@@ -1742,7 +1742,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 400mm f/4.5 VR S</model>
+        <model>Nikkor Z 400mm f/4.5 VR S</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -1770,7 +1770,7 @@
 
     <lens>
         <maker>Nikon</maker>
-        <model>NIKKOR Z 50mm f/1.4</model>
+        <model>Nikkor Z 50mm f/1.4</model>
         <mount>Nikon Z</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>


### PR DESCRIPTION
By the by, I still don't feel what was done in slr-nikon.xml was the best choice, there was nothing wrong w/ [Nikon product names "AF-S Nikkor" and the like](https://imaging.nikon.com/imaging/lineup/lens/f-mount/)... Just removing "Nikon" in front would've been my preference.

Cf. also https://www.dpreview.com/products/nikon/lenses?subcategoryId=lenses&page=1