### PR TITLE
Model names Leica lenses

### DIFF
--- a/data/db/compact-leica.xml
+++ b/data/db/compact-leica.xml
@@ -171,8 +171,7 @@
     <lens>
         <maker>LEICA CAMERA AG</maker>
         <maker lang="en">Leica</maker>
-        <model>APO-SUMMICRON 1:2/43 ASPH.</model>
-        <model lang="en">APO-Summicron 43mm f/2 ASPH.</model>
+        <model>APO-Summicron 1:2/43 Asph.</model>
         <mount>leicaQ343</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>

--- a/data/db/mil-leica.xml
+++ b/data/db/mil-leica.xml
@@ -102,7 +102,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Summicron-TL 1:2/23 ASPH.</model>
+        <model>Summicron-TL 1:2/23 Asph.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -124,7 +124,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Summilux-TL 1:1.4/35 ASPH.</model>
+        <model>Summilux-TL 1:1.4/35 Asph.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -136,7 +136,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Elmarit-TL 1:2.8/18 ASPH.</model>
+        <model>Elmarit-TL 1:2.8/18 Asph.</model>
         <mount>Leica L</mount>
         <cropfactor>1.53</cropfactor>
         <calibration>
@@ -148,7 +148,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Vario-Elmarit-SL 1:2.8/24-70 ASPH.</model>
+        <model>Vario-Elmarit-SL 1:2.8/24-70 Asph.</model>
         <mount>Leica L</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -164,7 +164,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>APO-Summicron-SL 1:2/50 ASPH.</model>
+        <model>APO-Summicron-SL 1:2/50 Asph.</model>
         <mount>Leica L</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -176,7 +176,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>APO-Summicron-SL 1:2/35 ASPH.</model>
+        <model>APO-Summicron-SL 1:2/35 Asph.</model>
         <mount>Leica L</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>

--- a/data/db/rf-leica.xml
+++ b/data/db/rf-leica.xml
@@ -179,8 +179,8 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Summicron-M 1:2/35mm Asph.</model>
-        <model lang="en">Summicron-M 1:2/35mm Asph. (11879/11882)</model>
+        <model>Summicron-M 1:2/35 Asph.</model>
+        <model lang="en">Summicron-M 1:2/35 Asph. (11879/11882)</model>
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -193,8 +193,8 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>APO-Summicron-M 1:2/75mm Asph.</model>
-        <model lang="en">APO-Summicron-M 1:2/75mm Asph. (11673/11701)</model>
+        <model>APO-Summicron-M 1:2/75 Asph.</model>
+        <model lang="en">APO-Summicron-M 1:2/75 Asph. (11673/11701)</model>
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>

--- a/data/db/rf-leica.xml
+++ b/data/db/rf-leica.xml
@@ -128,8 +128,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Elmarit-M 1:2.8/28 ASPH.</model>
-        <model lang="en">Elmarit-M 28mm f/2.8 ASPH</model>
+        <model>Elmarit-M 1:2.8/28 Asph.</model>
         <mount>Leica M</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -142,7 +141,6 @@
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
         <model>Elmarit-M 1:2.8/90</model>
-        <model lang="en">Elmarit-M 90mm f/2.8</model>
         <mount>Leica M</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -156,7 +154,6 @@
         <maker lang="en">Leica</maker>
         <model>Summicron-M 1:2/50</model>
         <!-- Model 11819/11825/11826/11816 -->
-        <model lang="en">Summicron-M 50mm f/2</model>
         <mount>Leica M</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -169,7 +166,7 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Summicron-M 1:2/28 ASPH.</model>
+        <model>Summicron-M 1:2/28 Asph.</model>
         <mount>Leica M</mount>
         <cropfactor>1</cropfactor>
         <calibration>
@@ -182,8 +179,8 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Summicron M 1:2/35mm ASPH.</model>
-        <model lang="en">Summicron M 1:2/35mm ASPH. (11879/11882)</model>
+        <model>Summicron-M 1:2/35mm Asph.</model>
+        <model lang="en">Summicron-M 1:2/35mm Asph. (11879/11882)</model>
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -196,8 +193,8 @@
     <lens>
         <maker>Leica Camera AG</maker>
         <maker lang="en">Leica</maker>
-        <model>Apo-Summicron-M 1:2/75mm ASPH.</model>
-        <model lang="en">Apo-Summicron M 1:2/75mm ASPH.(11673/11701)</model>
+        <model>APO-Summicron-M 1:2/75mm Asph.</model>
+        <model lang="en">APO-Summicron-M 1:2/75mm Asph. (11673/11701)</model>
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>


### PR DESCRIPTION
About model names of Leica lenses. `Exiv2 `reports these tags: `APO-SUMMICRON-SL 1:2/35 ASPH.` `APO-SUMMICRON 1:2/43 ASPH.`
Apparently the exif-tags are reported in all-caps.

Counting the names of Leica lenses in the lensfun-database result: 
9 names: like APO-Summicron-SL 1:2/35 ASPH.
3 names: like Elmarit-M 90mm f/2.8

The notation in the lensfun-database of the 9 lenses is almost equal to the exif-tag, except for character-case. The 3 other lenses use an f/xx style.

Here is my proposal:
Since lens matching is case-insensitive and after reading https://github.com/lensfun/lensfun/pull/2526 :
* for Leica lenses
* simplify the database by only using the exif-tag in `<model>` and removing `<model lang="en">`
* exception: some models are extended by e.g. (11879/11882). There are many generations of Summicrons that are identified by this number. For this `<model lang="en">` is used
* change case according to
-- Acronym type abbreviations: APO not Apo
-- Title case: Summicron, Summilux, Elmarit, Vario-Elmarit
-- Abbreviation: Asph. not ASPH.
-- Apperture and focallength: fractional notation, e.g. 1:2.8, followed by /focallength