### PR TITLE
Correct Panasonic lens names

### DIFF
--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -522,7 +522,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
+<!--    <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -666,7 +666,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
+<!--    <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="5.6"/>
@@ -752,7 +752,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
+<!--    <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>   -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -990,7 +990,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
+<!--    <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>   -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="140"/>
         <aperture min="4" max="22"/>
@@ -1415,7 +1415,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
-        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
+<!--    <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <focal min="100" max="300"/>
         <aperture min="4" max="22"/>
@@ -1754,7 +1754,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
+<!--    <model lang="en">Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1789,7 +1789,7 @@
         <!-- copy of the non-"II" profile, optics reported to be the same -->
         <maker>Panasonic</maker>
         <model>Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
+<!--    <model lang="en">Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>   -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1945,7 +1945,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
+<!--    <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>   -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <calibration>
@@ -2092,7 +2092,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>
+   <!-- <model lang="en">Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>    -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>

--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -522,7 +522,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -666,7 +666,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II</model>
+        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="5.6"/>
@@ -752,7 +752,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79x</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -990,7 +990,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8</model>
+        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="140"/>
         <aperture min="4" max="22"/>
@@ -1415,7 +1415,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
-        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6</model>
+        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="100" max="300"/>
         <aperture min="4" max="22"/>
@@ -1754,7 +1754,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8</model>
+        <model lang="en">Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1789,7 +1789,7 @@
         <!-- copy of the non-"II" profile, optics reported to be the same -->
         <maker>Panasonic</maker>
         <model>Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II</model>
+        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1945,7 +1945,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6</model>
+        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <calibration>
@@ -2077,6 +2077,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Leica DG Macro-Elmarit 45mm f/2.8</model>
+        <model lang="en">Leica DG Macro-Elmarit 45mm f/2.8 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -2091,7 +2092,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario PZ 45-175mm f/4.0-5.6</model>
+        <model lang="en">Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -2220,6 +2221,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G 14mm f/2.5 II</model>
+        <model lang="en">Lumix G 14mm f/2.5 II Asph.</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>

--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -751,7 +751,7 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79×</model>
+        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79x</model>
         <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>

--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -522,7 +522,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
-<!--    <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -666,7 +665,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
-<!--    <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="5.6"/>
@@ -752,7 +750,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
-<!--    <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>   -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -990,7 +987,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
-<!--    <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>   -->
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="140"/>
         <aperture min="4" max="22"/>
@@ -1415,7 +1411,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
-<!--    <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <focal min="100" max="300"/>
         <aperture min="4" max="22"/>
@@ -1754,7 +1749,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
-<!--    <model lang="en">Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>  -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1789,7 +1783,6 @@
         <!-- copy of the non-"II" profile, optics reported to be the same -->
         <maker>Panasonic</maker>
         <model>Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
-<!--    <model lang="en">Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>   -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1945,7 +1938,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
-<!--    <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>   -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <calibration>
@@ -2092,7 +2084,6 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>
-   <!-- <model lang="en">Lumix G X Vario PZ 45-175mm f/4.0-5.6 Asph. Power OIS</model>    -->
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>

--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -521,8 +521,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6</model>
+        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -665,8 +665,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II</model>
+        <model>Lumix G Vario 14-42mm f/3.5-5.6 II</model>
+        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="5.6"/>
@@ -751,8 +751,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79×</model>
+        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79×</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -989,8 +989,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8</model>
+        <model>Lumix G Vario HD 14-140mm f/4.0-5.8</model>
+        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="140"/>
         <aperture min="4" max="22"/>
@@ -1312,7 +1312,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Vario 45-200mm f/4.0-5.6 II</model>
-        <model lang="en">Lumix G Vario 45-200mm f/4.0-5.6 II power OIS</model>
+        <model lang="en">Lumix G Vario 45-200mm f/4.0-5.6 II Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1414,8 +1414,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
-        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6</model>
+        <model>Lumix G Vario 100-300mm f/4.0-5.6</model>
+        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal min="100" max="300"/>
         <aperture min="4" max="22"/>
@@ -1753,8 +1753,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8</model>
+        <model>Lumix G X Vario 12-35mm f/2.8</model>
+        <model lang="en">Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1788,8 +1788,8 @@
     <lens>
         <!-- copy of the non-"II" profile, optics reported to be the same -->
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II</model>
+        <model>Lumix G X Vario 12-35mm f/2.8 II</model>
+        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1944,8 +1944,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
-        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6</model>
+        <model>Lumix G Vario 45-150mm f/4.0-5.6</model>
+        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <calibration>
@@ -2249,6 +2249,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G 42.5mm f/1.7</model>
+        <model lang="en">Lumix G 42.5mm f/1.7 Asph. Power OIS</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -2786,6 +2787,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G Macro 30mm f/2.8</model>
+        <model lang="en">Lumix G Macro 30mm f/2.8 Asph. Mega OIS</model>
         <mount>Micro 4/3 System</mount>
         <focal value="30"/>
         <aperture min="2.8" max="22"/>
@@ -3063,6 +3065,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Leica D Summilux 25mm F1.4 Asph.</model>
+        <model lang="en">Leica D Summilux 25mm f/1.4 Asph.</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <calibration>
@@ -3117,12 +3120,12 @@
     <lens>
         <maker>Panasonic</maker>
         <model>LEICA DG SUMMILUX 9/F1.7</model>
-        <model lang="en">Leica DG Summilux 9mm f/1.7</model>
+        <model lang="en">Leica DG Summilux 9mm f/1.7 Asph.</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
         <calibration>
-	    <!-- Taken with DMC-GX8 -->
+            <!-- Taken with DMC-GX8 -->
             <distortion model="ptlens" focal="9" a="0.02807" b="-0.09826" c="0.02753"/>
             <tca model="poly3" focal="9" vr="1.0002079" vb="1.0002006"/>
         </calibration>
@@ -3135,7 +3138,7 @@
         <mount>Leica L</mount>
         <cropfactor>1</cropfactor>
         <calibration>
-             <!-- Taken with Leica SL2 -->
+            <!-- Taken with Leica SL2 -->
             <distortion model="ptlens" focal="16" a="0.020567" b="-0.0595563" c="-0.0351097"/>
             <distortion model="ptlens" focal="20" a="0.00918976" b="-0.0270337" c="-0.0301751"/>
             <distortion model="ptlens" focal="24" a="0.00735381" b="-0.0221845" c="-0.0125501"/>

--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -521,8 +521,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
+        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -665,8 +665,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario 14-42mm f/3.5-5.6 II</model>
-        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
+        <model>Lumix G Vario 14-42mm f/3.5-5.6 II Asph. Mega OIS</model>
+        <model lang="en">Lumix G Vario 14-42mm f/3.5-5.6 II</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="5.6"/>
@@ -751,8 +751,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79x</model>
-        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
+        <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 + GWC1 0.79x</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>
@@ -989,8 +989,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario HD 14-140mm f/4.0-5.8</model>
-        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
+        <model>Lumix G Vario HD 14-140mm f/4.0-5.8 Asph. Mega OIS</model>
+        <model lang="en">Lumix G Vario HD 14-140mm f/4.0-5.8</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="140"/>
         <aperture min="4" max="22"/>
@@ -1414,8 +1414,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario 100-300mm f/4.0-5.6</model>
-        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
+        <model>Lumix G Vario 100-300mm f/4.0-5.6 Mega OIS</model>
+        <model lang="en">Lumix G Vario 100-300mm f/4.0-5.6</model>
         <mount>Micro 4/3 System</mount>
         <focal min="100" max="300"/>
         <aperture min="4" max="22"/>
@@ -1753,8 +1753,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario 12-35mm f/2.8</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
+        <model>Lumix G X Vario 12-35mm f/2.8 Asph. Power OIS</model>
+        <model lang="en">Lumix G X Vario 12-35mm f/2.8</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1788,8 +1788,8 @@
     <lens>
         <!-- copy of the non-"II" profile, optics reported to be the same -->
         <maker>Panasonic</maker>
-        <model>Lumix G X Vario 12-35mm f/2.8 II</model>
-        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
+        <model>Lumix G X Vario 12-35mm f/2.8 II Asph. Power OIS</model>
+        <model lang="en">Lumix G X Vario 12-35mm f/2.8 II</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -1944,8 +1944,8 @@
 
     <lens>
         <maker>Panasonic</maker>
-        <model>Lumix G Vario 45-150mm f/4.0-5.6</model>
-        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
+        <model>Lumix G Vario 45-150mm f/4.0-5.6 Asph. Mega OIS</model>
+        <model lang="en">Lumix G Vario 45-150mm f/4.0-5.6</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
         <calibration>


### PR DESCRIPTION
* some white space formatting
* swapped tags `<model>` and `<model lang="en">`
* added Asph., Mega, Power (not power) where appropriate
* corrected lens names and checked with panasonic.com

On a side note: I would like to see the lens name EXIF-tag as-is in the `<model>` line; maybe in some cases allow different capitalization. But I don't have that information.