### PR TITLE
Fix Canon RF naming style for consistency

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -2206,7 +2206,7 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>Canon RF 24mm 1.4 L VCM</model>
+        <model>Canon RF 24mm F1.4 L VCM</model>
         <mount>Canon RF</mount>
         <cropfactor>1</cropfactor>
         <calibration>

--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -2190,7 +2190,7 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>Canon RF 28-70mm f/2.8 IS STM</model>
+        <model>Canon RF 28-70mm F2.8 IS STM</model>
         <mount>Canon RF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
@@ -2206,7 +2206,7 @@
 
     <lens>
         <maker>Canon</maker>
-        <model>Canon RF 24mm f/1.4 L VCM</model>
+        <model>Canon RF 24mm 1.4 L VCM</model>
         <mount>Canon RF</mount>
         <cropfactor>1</cropfactor>
         <calibration>


### PR DESCRIPTION
The Exif itself (and Canon marketing) uses the "F" rather than "f/" notation for the recent RF series, as do most lenses in the database already.