### PR TITLE
Add M39 mount, next to M39/1

### DIFF
--- a/data/db/generic.xml
+++ b/data/db/generic.xml
@@ -29,6 +29,7 @@
         <compat>Leica L</compat>
         <compat>M42</compat>
         <compat>M39/1</compat>
+        <compat>M39</compat>
         <compat>DKL</compat>
         <compat>Mamiya 645</compat>
         <compat>Micro 4/3 System</compat>


### PR DESCRIPTION
In the current lensfun database one M39/1 mount is listed.

However, shameless copy from [Wikipedia M39 lens mount](https://en.wikipedia.org/wiki/M39_lens_mount) there are variants of the true Leica Thread-Mount (LTM) which is 39 mm in diameter and has a thread of 26 turns-per-inch or threads-per-inch (tpi) (approximately 0.977 mm pitch) of Whitworth thread form.

The Soviets in the 1930s produced their early FED cameras in M39×1 (39 mm by 1 mm DIN thread).

In the lensfun database some lenses are listed as M39 and some as M39/1.

Therefor, make sure both M39/1 and M39 are in generic.xml

Personal note: I don't know if this is the right way to add a lens mount. If not, please let me know the right approach.