### PR TITLE
Fix show_lensfun_coverage.py

### DIFF
--- a/tools/lenslist/show_lensfun_coverage.py
+++ b/tools/lenslist/show_lensfun_coverage.py
@@ -16,10 +16,10 @@ import shutil
 def find_best(root, tagname):
     texts = [(len(element.text), element.text) for element in root.findall(tagname) if element.attrib.get("lang") == "en"]
     if texts:
-        return sorted(texts)[0][1]
-    texts = [(len(element.text), element.text) for element in root.findall(tagname)]
+        return (texts)[0][1]
+    texts = [(len(element.text), element.text) for element in root.findall(tagname) if not element.attrib.get("lang")]
     if texts:
-        return sorted(texts)[0][1]
+        return (texts)[0][1]
     else: 
         return None
 


### PR DESCRIPTION
On the list of supported lenses ( https://lensfun.github.io/lenslist/ and https://wilson.bronger.org/lensfun_coverage.html ):
some lens model names are listed in Russian, expected those lenses listed in English. Examples:
KMZ - МИР-1B 2.8/37
KMZ - ЮПИТЕР-37AM MC 3.5/135
MTO- МТО-500 500мм f/8
Also see https://github.com/lensfun/lensfun/pull/2556#issuecomment-3232773859

The xml file lists English model-names, and has Russion translation. However not the default English name is shown, but the translation.

Also another observation, there are entries in `slr-ussr.xml`, but not in the list, eg.: 
KMZ - MC Variozenitar
KMZ - MC APO Telezenitar
BelOMO - MC Peleng

Solution in this PR, as suggested in https://github.com/lensfun/lensfun/pull/2556#issuecomment-3234604629 (thanks!):
First find lang="en" element, otherwise find default element without lang attribute

It is safe to assume that there is 1 `<model>` line and that `<model lang="xx">` lines are unique. Pick at most 1 line, i.e. the `lang="en"` line. There is no need to sort. And if there are multiple entries -which shouldn't happen- there is no need to sort them.

The "missing" lenses don't have any calibration data in the corresponding xml files. This is OK: lenses without data should not be listed. What is the use of lens-descriptions without calibration data in the xml files? Maybe we better remove those lenses completely from the xml files?

Tested this on my machine. Results are as expected/OK.

Please have a look
 