### PR TITLE
Restore times symbol in lens display names instead of regular x

### DIFF
--- a/data/db/mil-panasonic.xml
+++ b/data/db/mil-panasonic.xml
@@ -454,6 +454,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G 14mm f/2.5 Asph. + GWC1 0.79x</model>
+        <model lang="en">Lumix G 14mm f/2.5 Asph. + GWC1 0.79×</model>
         <mount>Micro 4/3 System</mount>
         <focal value="14"/>
         <aperture min="2.5" max="22"/>
@@ -750,6 +751,7 @@
     <lens>
         <maker>Panasonic</maker>
         <model>Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79x</model>
+        <model lang="en">Lumix G X Vario PZ 14-42mm f/3.5-5.6 Asph. Power OIS + GWC1 0.79×</model>
         <mount>Micro 4/3 System</mount>
         <focal min="14" max="42"/>
         <aperture min="3.5" max="22"/>

--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -8334,6 +8334,7 @@
     <lens>
         <maker>Canon</maker>
         <model>Canon EF 100-400mm f/4.5-5.6L IS II USM + 1.4x extender</model>
+        <model lang="en">Canon EF 100-400mm f/4.5-5.6L IS II USM + 1.4× ext.</model>
         <mount>Canon EF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>

--- a/data/db/slr-olympus.xml
+++ b/data/db/slr-olympus.xml
@@ -800,6 +800,7 @@
     <lens>
         <maker>Olympus</maker>
         <model>Olympus Zuiko Digital ED 50-200mm f/2.8-3.5 SWD + EC-14 1.4x extender</model>
+        <model lang="en">Olympus Zuiko Digital ED 50-200mm f/2.8-3.5 SWD + EC-14 1.4× extender</model>
         <mount>4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>
@@ -861,6 +862,7 @@
     <lens>
         <maker>Olympus</maker>
         <model>Olympus Zuiko Digital ED 50-200mm f/2.8-3.5 SWD + EC-20 2x extender</model>
+        <model lang="en">Olympus Zuiko Digital ED 50-200mm f/2.8-3.5 SWD + EC-20 2× extender</model>
         <mount>4/3 System</mount>
         <cropfactor>2.0</cropfactor>
         <aspect-ratio>4:3</aspect-ratio>

--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -4640,7 +4640,7 @@
     <lens>
         <maker>Sigma</maker>
         <model>60-600mm f/4.5-6.3 DG OS HSM | Sports 018 +1.4x extender</model>
-        <model lang="en">Sigma 60-600mm F4.5-6.3 DG OS HSM | Sports 018 + 1.4x ext.</model>
+        <model lang="en">Sigma 60-600mm F4.5-6.3 DG OS HSM | Sports 018 + 1.4× ext.</model>
         <mount>Canon EF-S</mount>
         <cropfactor>1.605</cropfactor>
         <calibration>


### PR DESCRIPTION
Restore × (times symbol) in English and German lens display names instead of regular x.

Make display names consistent.
Don't touch `<model>` line.
Edit `<model lang="en">` only.

See also https://github.com/lensfun/lensfun/pull/2557