### PR TITLE
Restore previously deleted lens "smc Pentax-DA 55-300mm f/4-5.8 ED"

### DIFF
--- a/data/db/slr-pentax.xml
+++ b/data/db/slr-pentax.xml
@@ -1219,6 +1219,15 @@
 
     <lens>
         <maker>Pentax</maker>
+        <model>smc Pentax-DA 55-300mm f/4-5.8 ED</model>
+        <mount>Pentax KAF</mount>
+        <cropfactor>1.522</cropfactor>
+        <calibration>
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Pentax</maker>
         <model>smc Pentax-DA 15mm f/4 ED AL Limited</model>
         <mount>Pentax KAF2</mount>
         <!-- Average crop factor of Pentax APS-C cameras -->


### PR DESCRIPTION
Restore lens smc Pentax-DA 55-300mm f/4-5.8 ED (was deleted in https://github.com/lensfun/lensfun/pull/2561 )
