### PR TITLE
Fix fixed lenses' listing in lenslist

### DIFF
--- a/tools/lenslist/show_lensfun_coverage.py
+++ b/tools/lenslist/show_lensfun_coverage.py
@@ -47,7 +47,7 @@ class Lens:
     def __init__(self, element, root, camtype):
         self.maker = find_best(element, "maker")
         self.model = find_best(element, "model")
-        if camtype == "compact":
+        if self.model.startswith("fixed lens"):
             mount = element.find("mount").text
             for camera in root.findall("camera"):
                 if camera.find("mount").text == mount:
@@ -57,7 +57,7 @@ class Lens:
                     if variant:
                         camname = camname + " " + variant
                     break
-            self.model = "Fixed lens {}".format(camname)
+            self.model = "{}, {}".format(camname,self.model)
         try:
             self.crop = float(element.find("cropfactor").text)
         except:


### PR DESCRIPTION
In [lenslist](https://lensfun.github.io/lenslist/) there are some fixed lenses, which are only listed anonymously, as ‘fixed lens.’ Lenslist script assumes all the fixed lenses are in `compact*.xml` files and for those, fomats the output accordingly, using `<model>` element. However there are fixed lense entries outside of `compact*.xml`.

This can be fixed by finding and moving all fixed lense entries to `compact*xml` (not all fixed lense cameras are compact cameras though).

Alternatively, lenslist script can be changed to identify fixed lenses not by their placement in specifically named XML files, but by `model lang=en` being ‘fixed lens’ and then composing the name in lenslist with a particular model from `model` element. This should not require changes to the database. Lens Coverage then woul look like in the attached file:

[lensfun_coverage.html.txt](https://github.com/user-attachments/files/22083403/lensfun_coverage.html.txt)

Thoughts?
