### PR TITLE
Added all available mounts to Sigma 12-24 f/4 lens

### DIFF
--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -257,6 +257,11 @@
         <maker>Sigma</maker>
         <model>Sigma 12-24mm F4 DG HSM | A</model>
         <mount>Nikon F AF</mount>
+        <mount>Sigma SA</mount>
+        <mount>Canon EF</mount>
+        <mount>Pentax KAF2</mount>
+        <mount>Sony Alpha</mount>
+        <mount>4/3 System</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="12.0" a="0.021" b="-0.083" c="0.094" />


### PR DESCRIPTION
The Sigma 12-24 f/4 Art Lens is also available for Canon EF. The attached image can be used for testing the existing calibration data with the lens using a Canon EF mount.

[IMG_0012.zip](https://github.com/user-attachments/files/22297909/IMG_0012.zip)
