### PR TITLE
Cleanup: Remove unused implementations

### DIFF
--- a/libs/lensfun/camera.cpp
+++ b/libs/lensfun/camera.cpp
@@ -76,11 +76,6 @@ bool lfCamera::Check ()
 
 //---------------------------// The C interface //---------------------------//
 
-lfCamera *lf_camera_new ()
-{
-    return new lfCamera ();
-}
-
 lfCamera *lf_camera_create ()
 {
     return new lfCamera ();

--- a/libs/lensfun/database.cpp
+++ b/libs/lensfun/database.cpp
@@ -1548,16 +1548,10 @@ const char* const lf_db_system_updates_location = lfDatabase::SystemUpdatesLocat
 const char* const lf_db_user_location = lfDatabase::UserLocation;
 const char* const lf_db_user_updates_location = lfDatabase::UserUpdatesLocation;
 
-lfDatabase *lf_db_new ()
-{
-    return new lfDatabase ();
-}
-
 lfDatabase *lf_db_create ()
 {
     return new lfDatabase ();
 }
-
 
 void lf_db_destroy (lfDatabase *db)
 {

--- a/libs/lensfun/lens.cpp
+++ b/libs/lensfun/lens.cpp
@@ -1371,11 +1371,6 @@ gint _lf_lens_name_compare (const lfLens *i1, const lfLens *i2)
 
 //---------------------------// The C interface //---------------------------//
 
-lfLens *lf_lens_new ()
-{
-    return new lfLens ();
-}
-
 lfLens *lf_lens_create ()
 {
     return new lfLens ();

--- a/libs/lensfun/mount.cpp
+++ b/libs/lensfun/mount.cpp
@@ -92,11 +92,6 @@ bool lfMount::Check ()
 
 //---------------------------// The C interface //---------------------------//
 
-lfMount *lf_mount_new ()
-{
-    return new lfMount ();
-}
-
 lfMount *lf_mount_create ()
 {
     return new lfMount ();


### PR DESCRIPTION
The respective functions have already been removed from the public header in commit 35c0017.