### PR TITLE
Fix typos

### DIFF
--- a/data/db/mil-sigma.xml
+++ b/data/db/mil-sigma.xml
@@ -998,7 +998,7 @@
         <mount>Canon RF</mount>
         <cropfactor>1.534</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-6400, coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-6400, coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="10" a="0.0121299" b="-0.0481622" c="0.0044258" />
             <distortion model="ptlens" focal="12" a="0.0093819" b="-0.0289556" c="0.0024353" />
             <distortion model="ptlens" focal="15" a="0.0058474" b="-0.0101494" c="0.0003513" />

--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -1090,7 +1090,7 @@
         <cropfactor>1</cropfactor>
         <calibration>
             <!-- Taken with Nikon Z 6II -->
-            <!-- this lens has very bad vignetting in the corenrs around 2.8-4.0 apperture -->
+            <!-- this lens has very bad vignetting in the corners around 2.8-4.0 aperture -->
             <distortion model="ptlens" focal="50" a="0.00493" b="-0.02527" c="0.01242"/>
             <vignetting model="pa" focal="50" aperture="1.4" distance="10" k1="-1.1683" k2="0.8130" k3="-0.3889"/>
             <vignetting model="pa" focal="50" aperture="1.4" distance="1000" k1="-1.1683" k2="0.8130" k3="-0.3889"/>
@@ -2490,7 +2490,7 @@
         <mount>Leica M</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-            <!-- Taken with ILCE-7CM2, tca & vignetting coeffients fitted from exif data by lf_fitexif_se -->
+            <!-- Taken with ILCE-7CM2, tca & vignetting coefficients fitted from exif data by lf_fitexif_se -->
             <distortion model="ptlens" focal="28" a="0.010052" b="-0.0343339" c="0.0244028"/>
             <tca model="poly3" focal="28" vr="1.0007521" cr="-0.0004828" br="0.0001092" vb="0.9993413" cb="0.0004002" bb="0.0000667"/>
             <vignetting model="pa" focal="28" aperture="1.5" distance="10" k1="-2.1713419" k2="2.2736460" k3="-0.9439038"/>

--- a/docs/calibration_tutorial/lens_calibration_tutorial.rst
+++ b/docs/calibration_tutorial/lens_calibration_tutorial.rst
@@ -245,7 +245,7 @@ priority” and the lowest ISO.  Switch on manual focus.
 
 Focus at infinity.  (Despite the foil directly in front of the lens.)  Take
 pictures at maximal aperture and at three smaller apertures in 1 stop distance,
-and at the minimal aperature.  For zoom lenses, take pictures at five focal
+and at the minimal aperture.  For zoom lenses, take pictures at five focal
 lengths.  This makes 5 pictures for primes and 25 for zooms.
 
 Put the pictures in ``vignetting/``.

--- a/docs/make-release-0.3.x.txt
+++ b/docs/make-release-0.3.x.txt
@@ -100,7 +100,7 @@ SET(VERSION_API 1)
 
 ```
 
-12. Add `ChangLog`, `CMakeLists` and any other changed files and make a commit.
+12. Add `ChangeLog`, `CMakeLists` and any other changed files and make a commit.
 
 ```
 git add Changelog CMakeLists.txt

--- a/docs/man/README
+++ b/docs/man/README
@@ -7,4 +7,4 @@ call
 rst2man is part of the package python3-docutils.
 
 The .1 file are included for convenience into the repository.  They may be
-removed someday, possiby along with this README file.
+removed someday, possibly along with this README file.

--- a/tools/calibration_webserver/calibration/templates/calibration/upload.html
+++ b/tools/calibration_webserver/calibration/templates/calibration/upload.html
@@ -63,7 +63,7 @@ second straight line 1/3 of the image height from the top.</p>
 
 <p>The picture on the left is a good example.  The numbered marks follow the
 two lines that I mentioned.  I recommend that you use a modern building and
-take pictures of it.  Don't take picures of brick walls or tiles.  Tilting or
+take pictures of it.  Don't take pictures of brick walls or tiles.  Tilting or
 rotating the camera is allowed.  Make really sharp pictures.  Switch off all
 corrections (some cameras do this even for RAWs).</p>
 


### PR DESCRIPTION
Fixes documentation and source comment typos.

Found via:  
`codespell -q 3 -S "*.svg,./ChangeLog,./sourceforge-archive,./berlios-archive" -L foto,ist,makro,merchantibility,nd,oder,ois,optio,synching`