### PR TITLE
Fix Tamron 18-400 name on Nikon mount

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -1848,7 +1848,7 @@
 
     <lens>
         <maker>Tamron</maker>
-        <model>Tamron 18-400mm f/3.5-6.3 Di II VC HLD (B028)</model>
+        <model>Tamron AF 18-400mm f/3.5-6.3 Di II VC HLD (B028)</model>
         <mount>Canon EF</mount>
         <mount>Nikon F AF</mount>
         <cropfactor>1.53</cropfactor>


### PR DESCRIPTION
Darktable shows an EXIF name of `Tamron AF 18-400mm F/3.5-6.3 Di II VC HLD` on Nikon. Adding the "AF" part to the lensfun db lets it match automatically.


```
Exif.Nikon3.LensType                         Byte        1  D G VR
Exif.Nikon3.Lens                             Rational    4  18-400mm F3.5-6.3
Exif.Nikon3.LensFStops                       Undefined   4  5.33333
Exif.NikonLd3.LensIDNumber                   Byte        1  Tamron AF 18-400mm F/3.5-6.3 Di II VC HLD
Exif.NikonLd3.LensFStops                     Byte        1  F5.3

```