### PR TITLE
Improve TCA for Canon EF 16-35mm F/2.8L USM (I)

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -953,11 +953,11 @@
             <distortion model="ptlens" focal="28" a="0.010246756" b="-0.016053859" c="-0.000953533"/>
             <distortion model="ptlens" focal="30" a="0.010323046" b="-0.017679968" c="0.0047651725"/>
             <distortion model="ptlens" focal="35" a="0.0070163863" b="-0.010468312" c="0.0030782963"/>
-            <tca model="poly3" focal="16" br="-0.0002000" vr="1.0013882" bb="0.0001579" vb="0.9998360"/>
-            <tca model="poly3" focal="20" br="0.0000670" vr="1.0007432" bb="-0.0000362" vb="1.0002576"/>
-            <tca model="poly3" focal="24" br="0.0001425" vr="1.0003809" bb="-0.0001086" vb="1.0004253"/>
-            <tca model="poly3" focal="28" br="0.0001483" vr="1.0002688" bb="-0.0001237" vb="1.0003935"/>
-            <tca model="poly3" focal="35" br="0.0001437" vr="1.0002374" bb="-0.0001347" vb="1.0002667"/>
+            <tca model="poly3" focal="16.0" vr="1.00048" vb="1.00001" />
+            <tca model="poly3" focal="20.0" vr="1.00033" vb="1.00006" />
+            <tca model="poly3" focal="24.0" vr="1.00023" vb="1.00008" />
+            <tca model="poly3" focal="28.0" vr="1.00022" vb="1.00005" />
+            <tca model="poly3" focal="35.0" vr="1.00022" vb="0.99998" />
             <vignetting model="pa" focal="16" aperture="2.8" distance="0.28" k1="-0.1292" k2="-1.7458" k3="1.0127"/>
             <vignetting model="pa" focal="16" aperture="2.8" distance="0.56" k1="-0.3436" k2="-0.9369" k3="0.4790"/>
             <vignetting model="pa" focal="16" aperture="2.8" distance="1.68" k1="-0.3534" k2="-0.8520" k3="0.3689"/>


### PR DESCRIPTION
Fixes #2619

This lens at 16mm has very large changes in the corner depending on focus, with the TCA often varying by ±25%. 26mm and above are fairly similar to the previous calibration, but wider lengths are vastly different due to the difficulties composing & focusing at wider focal lengths in this lens.

In order to get better calibration data, I took 117 photos on a Canon EOS 6D, focusing on the limits of this lens. I used both tree branches and buildings. I ran them through Hugin's TCA detection, plus manually checked several in darktable, using "TCA override". Hugin was generally smaller than my manual checking, though not usually by too much. There was much variation in the computed values. 

I plotted the results in the following chart (`vr` only, `vb` was pretty boring). Open circles are Hugin's TCA detection, the black dotted line is the previous calibration, and the purple solid line is my proposed calibration. I generally biased slightly towards the larger end to match my manual checking in darktable, and I rounded the results to not imply greater significant figures. I reduced the model back to the simple `vr`/`vb` as I was unable to determine how to check or evaluate the model in darktable with the extra parameters `br`/`bb`, along with the fact that this lens is quite imprecise with regards to TCA.

<img width="880" height="770" alt="plot" src="https://github.com/user-attachments/assets/d30ad92d-48f3-4079-aa2b-e1c2d74ef458" />


Note:
- 28mm was hard to chose. I may need more photos in that spot, but my proposed settings seem like the best compromise based on the data I have
- `vb` was very simple, and had minimal changes compared to `vr`.
- In this plot, points are jittered horizontally for improved readability for the dense ends