### PR TITLE
Add TCA model for Canon TS-E 45mm f/2.8

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -5265,6 +5265,8 @@
         <cropfactor>1</cropfactor>
         <calibration>
             <distortion model="ptlens" focal="45" a="0.00211" b="-0.007388" c="0"/>
+            <!-- Taken with Canon EOS 6D -->
+            <tca model="poly3" focal="45" vr="1.00030" vb="1.00017" />
         </calibration>
     </lens>
 


### PR DESCRIPTION
TCA based on the average of 7 photos of treetops from a Canon EOS 6D. The trees were focused on from 40-50m away. Tilt and shift were locked at 0. I can provide more data at other positions, but I wasn't sure what do do with that, as per my comment https://github.com/lensfun/lensfun/discussions/2620. 

In order to evaluate the TCA data, I have provided a plot of each image (301-307) with the hugin (base of arrow) and my manual darktable (point of arrow) TCA values. Hugin did a good job on the `vr`, but failed to detect the `vb` shift.

The plot is `vb` vs `vr`, with each photo being an arrow from the automatic TCA detected values to my best manual calibration in darktable. I can upload them all if desired.

<img width="880" height="770" alt="plot45" src="https://github.com/user-attachments/assets/b660be9c-270f-488b-9132-7d5edf554cab" />
