### PR TITLE
std::aligned_alloc requires size to be a multiple of the alignment

### DIFF
--- a/tests/common_code.hpp
+++ b/tests/common_code.hpp
@@ -6,6 +6,13 @@ void* lf_alloc_align(size_t alignment, size_t size) {
 #ifdef _WIN32  // std::aligned_alloc isn't supported in Microsoft C Runtime library
     return _aligned_malloc(size, alignment);
 #else
+    // std::aligned_alloc requires size to be an integral multiple of alignment,
+    // otherwise it might return nullptr.
+    const size_t remainder = size % alignment;
+    if (remainder != 0) {
+        // adjust size to be multiple of alignment
+        size += alignment - remainder;
+    }
     return std::aligned_alloc(alignment, size);
 #endif
 }


### PR DESCRIPTION
Otherwise it may fail allocation and return a nullptr. At least on OSX and with Apple Clang this was the case and tests aborted with a segfault. See latest CI runs https://github.com/lensfun/lensfun/actions/runs/19396246562/job/55496674012.