### PR TITLE
Add full-frame lens profile for Canon EF 75-300 III

### DIFF
--- a/data/db/slr-canon.xml
+++ b/data/db/slr-canon.xml
@@ -8045,11 +8045,11 @@
         <cropfactor>1.005</cropfactor>
         <calibration>
             <!-- Taken with Canon 6D -->
-            <distortion model="ptlens" focal="75.0" a="0.00019" b="-0.01100" c="-0.00845" />
-            <distortion model="ptlens" focal="100.0" a="0.00249" b="-0.00933" c="0.00155" />
-            <distortion model="ptlens" focal="135.0" a="-0.00176" b="0.01038" c="-0.01093" />
-            <distortion model="ptlens" focal="200.0" a="-0.02696" b="0.10694" c="-0.1205" />
-            <distortion model="ptlens" focal="300.0" a="0.00280" b="0.00253" c="0.00506" />
+            <distortion model="ptlens" focal="75.0" a="-0.004784" b="0.017626" c="-0.024342" />
+            <distortion model="ptlens" focal="100.0" a="-0.000263" b="0.005345" c="-0.002066" />
+            <distortion model="ptlens" focal="135.0" a="0.001576" b="0.003967" c="-0.000041" />
+            <distortion model="ptlens" focal="200.0" a="-0.001069" b="0.01379" c="-0.006948" />
+            <distortion model="ptlens" focal="300.0" a="-0.001482" b="0.015891" c="-0.006023" />
             <tca model="poly3" focal="75.0"  vr="1.00012" vb="0.99997" />
             <tca model="poly3" focal="100.0" vr="1.00007" vb="0.99993" />
             <tca model="poly3" focal="135.0" vr="1.00000" vb="0.99960" />


### PR DESCRIPTION
This uses Bronger's calibrate.py for vignetting (sha256sum = cab4ac0dd7b6986ce281906306d704f5960e8d1e5378d0c5e2163ab1da4fa99c)

TCA was a manually-selected average of both automatic and manually-calibrated points
