### PR TITLE
Adding Sony RX100M7A which is a minor variant of RX100M7. The lens is…

### DIFF
--- a/data/db/compact-sony.xml
+++ b/data/db/compact-sony.xml
@@ -235,6 +235,14 @@
 
     <camera>
         <maker>Sony</maker>
+        <model>DSC-RX100M7A</model>
+        <model lang="en">RX100 VIIA</model>
+        <mount>sonyRX100VI</mount>
+        <cropfactor>2.66</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Sony</maker>
         <model>DSC-RX100M5A</model>
         <model lang="en">RX100 VA</model>
         <mount>sonyRX100III</mount>


### PR DESCRIPTION
… exactly the same, but due to different camera name, it was not recognized e.g. in DarkTable.