### PR TITLE
feat(db): add Laowa 15mm f/2.0 Zero-D

### DIFF
--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -953,6 +953,9 @@
     <lens>
         <maker>Venus</maker>
         <model>Laowa 15mm f/2.0 Zero-D</model>
+        <mount>Canon RF</mount>
+        <mount>Leica L</mount>
+        <mount>Nikon Z</mount>
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>


### PR DESCRIPTION
This is my first attempt to add a lens to the DB. I have no idea if the results are correct 🙂

---

The [`calibrate.py`](https://github.com/lensfun/lensfun/blob/95c1b4549fc75928e14d6c9cac7f532b2a254006/tools/calibrate/calibrate.py) script was used together with guidance from the [pixls.us article](https://pixls.us/articles/create-lens-calibration-data-for-lensfun/). Samples were taken using Sony A7III.

---

This lens is not only available in the Sone E mount but also in following mounts:

* Canon RF
* Leica L
* Nikon Z
* Leica M - a notably different construction

Should any of these mounts be also listed?

# Samples

Darktable 5.4.0 exports using the profile.

## Vignetting f/8.0 Original

![f/8.0 original](https://github.com/user-attachments/assets/23d50a81-ce5e-4606-a991-b2602e203b56)

## Vignetting f/8.0 Corrected
![f8.0 corrected](https://github.com/user-attachments/assets/d7b8d577-0498-4401-af09-ab5b850f212f)

## Real world f/8.0 Original
![DSC01469_01](https://github.com/user-attachments/assets/570dc3e5-baeb-47a3-95f0-a86ba2348e3e)

## Real world f/8.0 Corrected
![DSC01469_02](https://github.com/user-attachments/assets/630e8b6d-c7da-4b39-9e09-9f62bcc3850a)


