### PR TITLE
Add TCA & Vignetting for Meike 85mm f/1.8

### DIFF
--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -867,7 +867,7 @@
         <!-- Note: the LensModel string is actually "SKY85mm f/1.8 DCM "$FIRMWARE_DATE so
                     the latest EF name is "SKY85mm f/1.8 DCM Mar  7", but that is terrile to match
                     so we list this as the actual lens name -->
-        <model>Meike 85mm f/1.8 DCM</model>
+        <model>Meike 85mm f/1.8</model>
         <mount>Nikon F AF</mount>
         <mount>Canon EF</mount>
         <mount>Fujifilm X</mount>


### PR DESCRIPTION
Note that the Exif Data shows "SKY85mm" and includes the firmware date. As per https://github.com/lensfun/lensfun/issues/2712 this will be a manual selection.

Related: https://github.com/Exiv2/exiv2/pull/3496