### PR TITLE
Add vignetting and EF mount for Samyang/Rokinon 14mm

### DIFF
--- a/data/db/mil-samyang.xml
+++ b/data/db/mil-samyang.xml
@@ -149,7 +149,6 @@
         <calibration>
             <!-- Taken with ILCE-7M2 -->
             <distortion model="ptlens" focal="14" a="0.04751" b="-0.16492" c="0.1496"/>
-
             <!-- Taken with Canon EOS 6D -->
             <tca model="poly3" focal="14" vr="1.00020" vb="0.99997" />
             <vignetting model="pa" focal="14" aperture="2.8" distance="10" k1="-1.4629" k2="0.8387" k3="-0.1602"/>


### PR DESCRIPTION
I kept it in mil-samyang as thats where it was, but as this is the EF mount, I suppose I could move it to the slr-samyang page istead