### PR TITLE
Panasonic model cleanup

### DIFF
--- a/data/db/compact-panasonic.xml
+++ b/data/db/compact-panasonic.xml
@@ -418,21 +418,6 @@
     </camera>
 
     <camera>
-        <maker>Panasonic</maker>
-        <model>DMC-TZ90</model>
-        <mount>panasonicTZ70</mount>
-        <cropfactor>5.58</cropfactor>
-    </camera>
-
-    <camera>
-        <!-- German version of TZ90 -->
-        <maker>Panasonic</maker>
-        <model>DMC-TZ91</model>
-        <mount>panasonicTZ70</mount>
-        <cropfactor>5.58</cropfactor>
-    </camera>
-
-    <camera>
         <!-- Swedish version of TZ90 -->
         <maker>Panasonic</maker>
         <model>DC-TZ90</model>
@@ -441,15 +426,23 @@
     </camera>
 
     <camera>
+        <!-- German version of TZ90 -->
         <maker>Panasonic</maker>
-        <model>DC-TZ99</model>
+        <model>DC-TZ91</model>
+        <mount>panasonicTZ70</mount>
+        <cropfactor>5.58</cropfactor>
+    </camera>
+
+    <camera>
+        <maker>Panasonic</maker>
+        <model>DC-TZ96</model>
         <mount>panasonicTZ70</mount>
         <cropfactor>5.58</cropfactor>
     </camera>
     
     <camera>
         <maker>Panasonic</maker>
-        <model>DMC-TZ96</model>
+        <model>DC-TZ99</model>
         <mount>panasonicTZ70</mount>
         <cropfactor>5.58</cropfactor>
     </camera>
@@ -457,7 +450,7 @@
     <camera>
         <!-- North American version of TZ90 -->
         <maker>Panasonic</maker>
-        <model>DMC-ZS70</model>
+        <model>DC-ZS70</model>
         <mount>panasonicTZ70</mount>
         <cropfactor>5.58</cropfactor>
     </camera>


### PR DESCRIPTION
Since TZ9x and ZS70 there is only the DC- prefix.