### PR TITLE
Add Tamron A078 vignetting correction

### DIFF
--- a/data/db/mil-tamron.xml
+++ b/data/db/mil-tamron.xml
@@ -963,6 +963,56 @@
             <tca model="poly3" focal="70" vr="1.0000034" vb="0.9999859"/>
             <tca model="poly3" focal="85" vr="0.9999522" vb="0.9999623"/>
             <tca model="poly3" focal="100" vr="0.9999091" vb="0.9999670"/>
+			<vignetting model="pa" focal="35.0" aperture="2.8" distance="10" k1="-0.0241994" k2="-1.6713152" k3="0.9398465" />
+            <vignetting model="pa" focal="35.0" aperture="2.8" distance="1000" k1="-0.0241994" k2="-1.6713152" k3="0.9398465" />
+            <vignetting model="pa" focal="35.0" aperture="4.0" distance="10" k1="-0.1428209" k2="-0.2511256" k3="-0.1854741" />
+            <vignetting model="pa" focal="35.0" aperture="4.0" distance="1000" k1="-0.1428209" k2="-0.2511256" k3="-0.1854741" />
+            <vignetting model="pa" focal="35.0" aperture="5.6" distance="10" k1="-0.3912667" k2="0.4797809" k3="-0.4747123" />
+            <vignetting model="pa" focal="35.0" aperture="5.6" distance="1000" k1="-0.3912667" k2="0.4797809" k3="-0.4747123" />
+            <vignetting model="pa" focal="35.0" aperture="8.0" distance="10" k1="-0.2827972" k2="0.0012016" k3="-0.0015856" />
+            <vignetting model="pa" focal="35.0" aperture="8.0" distance="1000" k1="-0.2827972" k2="0.0012016" k3="-0.0015856" />
+            <vignetting model="pa" focal="35.0" aperture="22.0" distance="10" k1="-0.2545873" k2="-0.1028349" k3="0.0919660" />
+            <vignetting model="pa" focal="35.0" aperture="22.0" distance="1000" k1="-0.2545873" k2="-0.1028349" k3="0.0919660" />
+            <vignetting model="pa" focal="50.0" aperture="2.8" distance="10" k1="-0.1750749" k2="-0.7488477" k3="0.2429051" />
+            <vignetting model="pa" focal="50.0" aperture="2.8" distance="1000" k1="-0.1750749" k2="-0.7488477" k3="0.2429051" />
+            <vignetting model="pa" focal="50.0" aperture="4.0" distance="10" k1="-0.2419716" k2="0.2495244" k3="-0.4808661" />
+            <vignetting model="pa" focal="50.0" aperture="4.0" distance="1000" k1="-0.2419716" k2="0.2495244" k3="-0.4808661" />
+            <vignetting model="pa" focal="50.0" aperture="5.6" distance="10" k1="-0.3172392" k2="0.3571561" k3="-0.3376496" />
+            <vignetting model="pa" focal="50.0" aperture="5.6" distance="1000" k1="-0.3172392" k2="0.3571561" k3="-0.3376496" />
+            <vignetting model="pa" focal="50.0" aperture="8.0" distance="10" k1="-0.2330147" k2="-0.0249074" k3="0.0215908" />
+            <vignetting model="pa" focal="50.0" aperture="8.0" distance="1000" k1="-0.2330147" k2="-0.0249074" k3="0.0215908" />
+            <vignetting model="pa" focal="50.0" aperture="22.0" distance="10" k1="-0.2213459" k2="-0.0371799" k3="0.0337105" />
+            <vignetting model="pa" focal="50.0" aperture="22.0" distance="1000" k1="-0.2213459" k2="-0.0371799" k3="0.0337105" />
+            <vignetting model="pa" focal="70.0" aperture="2.8" distance="10" k1="-0.1205572" k2="-1.2271700" k3="0.6637704" />
+            <vignetting model="pa" focal="70.0" aperture="2.8" distance="1000" k1="-0.1205572" k2="-1.2271700" k3="0.6637704" />
+            <vignetting model="pa" focal="70.0" aperture="4.0" distance="10" k1="-0.0589126" k2="-0.2333922" k3="-0.1962225" />
+            <vignetting model="pa" focal="70.0" aperture="4.0" distance="1000" k1="-0.0589126" k2="-0.2333922" k3="-0.1962225" />
+            <vignetting model="pa" focal="70.0" aperture="5.6" distance="10" k1="-0.2791778" k2="0.4051533" k3="-0.4099609" />
+            <vignetting model="pa" focal="70.0" aperture="5.6" distance="1000" k1="-0.2791778" k2="0.4051533" k3="-0.4099609" />
+            <vignetting model="pa" focal="70.0" aperture="8.0" distance="10" k1="-0.2086010" k2="0.0629523" k3="-0.0551437" />
+            <vignetting model="pa" focal="70.0" aperture="8.0" distance="1000" k1="-0.2086010" k2="0.0629523" k3="-0.0551437" />
+            <vignetting model="pa" focal="70.0" aperture="22.0" distance="10" k1="-0.1873255" k2="-0.0219846" k3="0.0237963" />
+            <vignetting model="pa" focal="70.0" aperture="22.0" distance="1000" k1="-0.1873255" k2="-0.0219846" k3="0.0237963" />
+            <vignetting model="pa" focal="85.0" aperture="2.8" distance="10" k1="-0.3785203" k2="-1.0784587" k3="0.7452386" />
+            <vignetting model="pa" focal="85.0" aperture="2.8" distance="1000" k1="-0.3785203" k2="-1.0784587" k3="0.7452386" />
+            <vignetting model="pa" focal="85.0" aperture="4.0" distance="10" k1="0.1052720" k2="-0.8667326" k3="0.2538370" />
+            <vignetting model="pa" focal="85.0" aperture="4.0" distance="1000" k1="0.1052720" k2="-0.8667326" k3="0.2538370" />
+            <vignetting model="pa" focal="85.0" aperture="5.6" distance="10" k1="-0.2400119" k2="0.3335356" k3="-0.4134362" />
+            <vignetting model="pa" focal="85.0" aperture="5.6" distance="1000" k1="-0.2400119" k2="0.3335356" k3="-0.4134362" />
+            <vignetting model="pa" focal="85.0" aperture="8.0" distance="10" k1="-0.2362899" k2="0.2285859" k3="-0.2060615" />
+            <vignetting model="pa" focal="85.0" aperture="8.0" distance="1000" k1="-0.2362899" k2="0.2285859" k3="-0.2060615" />
+            <vignetting model="pa" focal="85.0" aperture="22.0" distance="10" k1="-0.1653134" k2="-0.0248528" k3="0.0278904" />
+            <vignetting model="pa" focal="85.0" aperture="22.0" distance="1000" k1="-0.1653134" k2="-0.0248528" k3="0.0278904" />
+            <vignetting model="pa" focal="100.0" aperture="2.8" distance="10" k1="-0.7972343" k2="-0.3756513" k3="0.4287661" />
+            <vignetting model="pa" focal="100.0" aperture="2.8" distance="1000" k1="-0.7972343" k2="-0.3756513" k3="0.4287661" />
+            <vignetting model="pa" focal="100.0" aperture="4.0" distance="10" k1="0.1803928" k2="-1.2849809" k3="0.5794470" />
+            <vignetting model="pa" focal="100.0" aperture="4.0" distance="1000" k1="0.1803928" k2="-1.2849809" k3="0.5794470" />
+            <vignetting model="pa" focal="100.0" aperture="5.6" distance="10" k1="-0.1554316" k2="0.1056485" k3="-0.2881861" />
+            <vignetting model="pa" focal="100.0" aperture="5.6" distance="1000" k1="-0.1554316" k2="0.1056485" k3="-0.2881861" />
+            <vignetting model="pa" focal="100.0" aperture="8.0" distance="10" k1="-0.2509769" k2="0.3366916" k3="-0.3194545" />
+            <vignetting model="pa" focal="100.0" aperture="8.0" distance="1000" k1="-0.2509769" k2="0.3366916" k3="-0.3194545" />
+            <vignetting model="pa" focal="100.0" aperture="22.0" distance="10" k1="-0.1534216" k2="-0.0248536" k3="0.0293977" />
+            <vignetting model="pa" focal="100.0" aperture="22.0" distance="1000" k1="-0.1534216" k2="-0.0248536" k3="0.0293977" />
         </calibration>
     </lens>
 


### PR DESCRIPTION
Hello,

I am the uploader of Tamron 35-100mm f/2.8 A078 Z mount distortion correction.
Due to lack of filter I was unable to shot vignetting correction at the time.

Now I have shot the vignetting photos and ran the script according to the guide, and generated vignetting correction profiles.

I have uploaded my sample pictures here: [Google Drive](https://drive.google.com/drive/folders/1v5nLoJoGa02hJTnuOxZ3aDLlN0ZmZ3Jy?usp=sharing)
You can take a look about my calibrations.

Example vignetting PDF: [WEI_0684.pdf](https://github.com/user-attachments/files/26807588/WEI_0684.pdf)

Please let me know if you have other questions regarding this PR.

Thanks!
