### PR TITLE
Add a simple table-filter function for the generated lens list HTML

### DIFF
--- a/tools/lenslist/show_lensfun_coverage.py
+++ b/tools/lenslist/show_lensfun_coverage.py
@@ -125,16 +125,19 @@ outfile = open(cmdline_args['outfile'], "w")
 # write HTML table or markdown formatted list
 if cmdline_args['markdown'] == False:
 
+    with open(os.path.join(os.path.dirname(__file__), 'table-sorting-script.js'), 'r') as input_file:
+        sorting_js = input_file.read()
+
     #----------------------------------------------------------------------
     # HTML table
     if cmdline_args['table_only'] == False:
-        outfile.write("<html><head><title>Lensfun's coverage</title></head><body><h1>Lensfun coverage</h1><h2>Lenses (count: {})</h2>"
+        outfile.write("<html><head><title>Lensfun's coverage</title><script>{}</script></head><body><h1>Lensfun coverage</h1><h2>Lenses (count: {})</h2>"
                   "<p>This table was generated on {} from current Lensfun sources.  Your Lensfun version may be older, resulting in "
                   "less coverage.  If your lens is not included, see</p><ul><li><a href='/calibration'>Upload calibration pictures</a>"
-                  "</li><li><a href='lens_calibration_tutorial/'>Lens calibration for Lensfun</a></li></ul>\n".format(
-                      len(lenses), datetime.date.today()))
+                  "</li><li><a href='lens_calibration_tutorial/'>Lens calibration for Lensfun</a></li></ul>Filter this table: <input type='search' id='searchbox' placeholder='Search terms' style='width: 40em; margin: 0.25em 0.5em;'/> <input type='button' id='searchclear' value='Clear' disabled/> (use '!' to negate a term)\n".format(sorting_js,
+                        len(lenses), datetime.date.today()))
 
-    outfile.write("<table border='1'><thead><tr><th>manufacturer</th><th>model</th><th>crop</th><th>dist.</th><th>TCA</th>"
+    outfile.write("<table border='1' id='searchableTable'><thead><tr><th>manufacturer</th><th>model</th><th>crop</th><th>dist.</th><th>TCA</th>"
                   "<th>vign.</th></tr></thead><tbody>\n")
     number_of_makers = 0
     previous_maker = None
@@ -143,8 +146,8 @@ if cmdline_args['markdown'] == False:
         if lens.maker.lower() != previous_maker:
             number_of_makers += 1
 
-        outfile.write("""<tr{}><td>{}</td><td>{}</td><td>{}</td><td{}</td><td{}</td><td{}</td></tr>\n""".format(
-            ' class="lenslist-bg1"' if number_of_makers % 2 else ' class="lenslist-bg2"',
+        outfile.write("""<tr{} data-maker="{}" data-model="{}" data-first="{}"><td>{}</td><td>{}</td><td>{}</td><td title="Distortion" {}</td><td title="TCA" {}</td><td title="Vignetting" {}</td></tr>\n""".format(
+            ' class="lenslist-bg1"' if number_of_makers % 2 else ' class="lenslist-bg2"', lens.maker, lens.model, lens.maker.lower() != previous_maker,
             lens.maker if lens.maker.lower() != previous_maker else "", lens.model, lens.crop or "?",
             print_x(lens.distortion), print_x(lens.tca), print_x(lens.vignetting)))
         previous_maker = lens.maker.lower()

--- a/tools/lenslist/table-sorting-script.js
+++ b/tools/lenslist/table-sorting-script.js
@@ -1,0 +1,71 @@
+/**
+ * This script adds simple search/fitler functionality to the html version
+ * of the lensfun coverage table.
+ *
+ * Example queries:
+ * `Canon` => Only shows Canon lenses
+ * `Canon !-` => Shows prime Canon lenses
+ * `Canon !- is` => Shows prime Canon lenses with Image Stabilization
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+
+    function fixupMakers(visibleRows) {
+        visibleRows.forEach((row, index) => {
+            const current = row.getAttribute('data-maker');
+            const prev = index > 0 ? visibleRows[index - 1].getAttribute('data-maker') : '';
+
+            // Hide sequential maker names if they are the same
+            if (current === prev) {
+                row.children[0].textContent = "";
+            } else {
+                row.children[0].textContent = current;
+            }
+        });
+    }
+
+    const rows = document.querySelectorAll('#searchableTable tbody tr');
+    const searchBox = document.getElementById('searchbox');
+    const clearButton = document.getElementById('searchclear');
+    searchBox.value = "";
+
+    // The main search box functionality
+    searchBox.addEventListener('input', function() {
+        // Split apart into valid search terms
+        const searchTerms = this.value.toLowerCase().split(' ').filter(term => term.length > 0 && (term.length > 1 || term[0] != '!'));
+        clearButton.disabled = (searchTerms.length > 0) ? "" : "disabled";
+
+        let visibleRows = [];
+        rows.forEach(row => {
+            const maker = row.getAttribute('data-maker').toLowerCase();
+            const model = row.getAttribute('data-model').toLowerCase();
+
+            let shouldShow = true; // if no search terms, show everything
+
+            if (searchTerms.length > 0) {
+                // A row must match ALL search terms
+                shouldShow = searchTerms.every(term => {
+                    if (term[0] == '!') {
+                        term = term.slice(1);
+                        return !(maker.includes(term) || model.includes(term));
+                    } else {
+                        return maker.includes(term) || model.includes(term)
+                    }
+                });
+            }
+
+            // directly update the visibility of each row that we are filtering
+            row.style.display = shouldShow ? '' : 'none';
+            if (shouldShow)
+                visibleRows.push(row);
+        });
+
+        fixupMakers(visibleRows); // rows may be missing, show the maker in the first visble rows
+    });
+
+    // The clear button will reset all searches
+    clearButton.addEventListener('click', function() {
+        searchBox.value = "";
+        searchBox.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+});


### PR DESCRIPTION
This adds an integrated search box to the generated lens list. I made some choises that can be revisited, but it is handy so far in the current state. I may also have missed some key things, but it seems to work fine when I generate it locally.

Notable things:
- Done entirely in a progressive-enhancement way with client-side JavaScript.
- Negatives and case-insensitivity are supported
- Searching on crop factor is not supported
- Regex and fancy searches are not supported
- Right now, the entire script is embedded in the output HTML
- The search box isn't styled and is fairly hard-coded

Screenshots of various searches:
<img width="1120" height="900" alt="Screenshot_20260421_225207" src="https://github.com/user-attachments/assets/67b2f723-d565-4c78-94fc-b8a9419cd1f7" />
<img width="1104" height="539" alt="Screenshot_20260421_224929" src="https://github.com/user-attachments/assets/fd719408-6ca0-4296-8253-df4f1ddc15cb" />
