### PR TITLE
Add Tamron 85mm f/1.8 VC with TCA & Vignetting

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -2246,6 +2246,35 @@
 
     <lens>
         <maker>Tamron</maker>
+        <model>Tamron SP 85mm f/1.8 Di VC USD F016</model>
+        <mount>Nikon F AF</mount>
+        <mount>Canon EF</mount>
+        <mount>Sony Alpha</mount>
+        <cropfactor>1.005</cropfactor>
+        <calibration>
+            <!-- Taken with Canon 6D -->
+            <tca model="poly3" focal="85" vr="1.00006" vb="1.00003"/>
+            <vignetting model="pa" focal="85" aperture="1.8" distance="0.74" k1="-1.1846" k2="0.7583" k3="-0.2251"/>
+            <vignetting model="pa" focal="85" aperture="1.8" distance="56.34" k1="-1.4786" k2="1.4753" k3="-0.6493"/>
+            <vignetting model="pa" focal="85" aperture="2.5" distance="0.74" k1="-0.3594" k2="-0.4368" k3="0.3101"/>
+            <vignetting model="pa" focal="85" aperture="2.5" distance="56.34" k1="0.0901" k2="-1.0996" k3="0.6196"/>
+            <vignetting model="pa" focal="85" aperture="3.5" distance="0.74" k1="0.0972" k2="-0.7508" k3="0.3350"/>
+            <vignetting model="pa" focal="85" aperture="3.5" distance="56.34" k1="-0.0364" k2="-0.1370" k3="-0.0524"/>
+            <vignetting model="pa" focal="85" aperture="5" distance="0.74" k1="-0.1994" k2="0.3523" k3="-0.3799"/>
+            <vignetting model="pa" focal="85" aperture="5" distance="56.34" k1="-0.1885" k2="0.2094" k3="-0.1387"/>
+            <vignetting model="pa" focal="85" aperture="7.1" distance="0.74" k1="-0.1994" k2="0.2296" k3="-0.1490"/>
+            <vignetting model="pa" focal="85" aperture="7.1" distance="56.34" k1="-0.1518" k2="0.0172" k3="0.0478"/>
+            <vignetting model="pa" focal="85" aperture="10" distance="0.74" k1="-0.1651" k2="0.0450" k3="0.0343"/>
+            <vignetting model="pa" focal="85" aperture="10" distance="56.34" k1="-0.1702" k2="0.0442" k3="0.0360"/>
+            <vignetting model="pa" focal="85" aperture="14" distance="0.74" k1="-0.1705" k2="0.0570" k3="0.0209"/>
+            <vignetting model="pa" focal="85" aperture="14" distance="56.34" k1="-0.1794" k2="0.0583" k3="0.0278"/>
+            <vignetting model="pa" focal="85" aperture="16" distance="0.74" k1="-0.1694" k2="0.0498" k3="0.0283"/>
+            <vignetting model="pa" focal="85" aperture="16" distance="56.34" k1="-0.1798" k2="0.0622" k3="0.0211"/>
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Tamron</maker>
         <model>Tamron SP AF 24-135mm F/3.5-5.6 AD Aspherical (IF) Macro</model>
         <mount>Nikon F AF</mount>
         <mount>Canon EF</mount>


### PR DESCRIPTION
This PR adds TCA & Vignetting for a new Tamron 85mm f/1.8 VC entry.

Taken with a Canon 6D. Vignetting test photos will be uploaded an linked a few minutes after I post this PR. Edit: https://github.com/lensfun/lensfun/issues/2773

I will try to find a suitable location for Distortion photos within the next month. If this PR is not merged by that point, I will update it with a distortion profile