### PR TITLE
Add TCA & Vignetting for Sigma 100-400 HSM C

### DIFF
--- a/data/db/slr-sigma.xml
+++ b/data/db/slr-sigma.xml
@@ -4041,6 +4041,77 @@
             <distortion model="ptlens" focal="269" a="0.000821006626724432" b="0.00696870281840183" c="-0.00006303401437"/>
             <distortion model="ptlens" focal="330" a="0.00270471180028591" b="0.000454590310574091" c="0.00747279128088757"/>
             <distortion model="ptlens" focal="400" a="0.00516432918992183" b="-0.00822130071724918" c="0.0155418218274517"/>
+            <!-- Taken with Canon 6D -->
+            <tca model="poly3" focal="100" vr="1.00027" vb="0.99998"/>
+            <tca model="poly3" focal="120" vr="1.00022" vb="1.00000"/>
+            <tca model="poly3" focal="145" vr="1.00017" vb="1.00002"/>
+            <tca model="poly3" focal="175" vr="1.00010" vb="1.00003"/>
+            <tca model="poly3" focal="200" vr="1.00003" vb="1.00004"/>
+            <tca model="poly3" focal="230" vr="0.99999" vb="1.00003"/>
+            <tca model="poly3" focal="260" vr="0.99997" vb="1.00002"/>
+            <tca model="poly3" focal="300" vr="0.99991" vb="1.00002"/>
+            <tca model="poly3" focal="400" vr="0.99984" vb="1.00000"/>
+            <vignetting model="pa" focal="100" aperture="5" distance="1.6" k1="-0.5778" k2="0.0339" k3="-0.0337"/>
+            <vignetting model="pa" focal="100" aperture="5" distance="81.91" k1="-0.5350" k2="-0.2286" k3="0.1421"/>
+            <vignetting model="pa" focal="100" aperture="7.1" distance="1.6" k1="-0.2000" k2="0.4205" k3="-0.5020"/>
+            <vignetting model="pa" focal="100" aperture="7.1" distance="81.91" k1="-0.1434" k2="0.2648" k3="-0.4681"/>
+            <vignetting model="pa" focal="100" aperture="10" distance="1.6" k1="-0.1499" k2="0.0851" k3="-0.0259"/>
+            <vignetting model="pa" focal="100" aperture="10" distance="81.91" k1="-0.1960" k2="0.2598" k3="-0.1861"/>
+            <vignetting model="pa" focal="100" aperture="14" distance="1.6" k1="-0.1331" k2="0.0218" k3="0.0303"/>
+            <vignetting model="pa" focal="100" aperture="14" distance="81.91" k1="-0.1343" k2="0.0214" k3="0.0293"/>
+            <vignetting model="pa" focal="100" aperture="20" distance="1.6" k1="-0.1362" k2="0.0278" k3="0.0267"/>
+            <vignetting model="pa" focal="100" aperture="20" distance="81.91" k1="-0.1342" k2="0.0198" k3="0.0306"/>
+            <vignetting model="pa" focal="100" aperture="22" distance="1.6" k1="-0.1379" k2="0.0325" k3="0.0232"/>
+            <vignetting model="pa" focal="100" aperture="22" distance="81.91" k1="-0.1330" k2="0.0158" k3="0.0335"/>
+            <vignetting model="pa" focal="135" aperture="5.6" distance="1.6" k1="-0.3411" k2="-0.1126" k3="0.0628"/>
+            <vignetting model="pa" focal="135" aperture="5.6" distance="81.91" k1="-0.3027" k2="-0.3758" k3="0.2236"/>
+            <vignetting model="pa" focal="135" aperture="8" distance="1.6" k1="-0.1486" k2="0.1288" k3="-0.0618"/>
+            <vignetting model="pa" focal="135" aperture="8" distance="81.91" k1="-0.1906" k2="0.3190" k3="-0.2623"/>
+            <vignetting model="pa" focal="135" aperture="11" distance="1.6" k1="-0.1287" k2="0.0468" k3="0.0148"/>
+            <vignetting model="pa" focal="135" aperture="11" distance="81.91" k1="-0.1280" k2="0.0422" k3="0.0185"/>
+            <vignetting model="pa" focal="135" aperture="16" distance="1.6" k1="-0.1314" k2="0.0555" k3="0.0078"/>
+            <vignetting model="pa" focal="135" aperture="16" distance="81.91" k1="-0.1293" k2="0.0459" k3="0.0154"/>
+            <vignetting model="pa" focal="135" aperture="22" distance="1.6" k1="-0.1324" k2="0.0583" k3="0.0063"/>
+            <vignetting model="pa" focal="135" aperture="22" distance="81.91" k1="-0.1304" k2="0.0509" k3="0.0115"/>
+            <vignetting model="pa" focal="135" aperture="25" distance="10" k1="-0.1315" k2="0.0519" k3="0.0111"/>
+            <vignetting model="pa" focal="135" aperture="25" distance="1000" k1="-0.1315" k2="0.0519" k3="0.0111"/>
+            <vignetting model="pa" focal="202" aperture="5.6" distance="1.6" k1="-0.0754" k2="-0.3743" k3="0.0733"/>
+            <vignetting model="pa" focal="202" aperture="5.6" distance="81.91" k1="0.0295" k2="-1.2148" k3="0.6811"/>
+            <vignetting model="pa" focal="202" aperture="8" distance="1.6" k1="-0.1854" k2="0.4479" k3="-0.4628"/>
+            <vignetting model="pa" focal="202" aperture="8" distance="81.91" k1="0.0521" k2="-0.3251" k3="-0.0654"/>
+            <vignetting model="pa" focal="202" aperture="11" distance="1.6" k1="-0.1461" k2="0.1831" k3="-0.1086"/>
+            <vignetting model="pa" focal="202" aperture="11" distance="81.91" k1="-0.2358" k2="0.6409" k3="-0.6326"/>
+            <vignetting model="pa" focal="202" aperture="16" distance="1.6" k1="-0.1112" k2="0.0478" k3="0.0127"/>
+            <vignetting model="pa" focal="202" aperture="16" distance="81.91" k1="-0.2021" k2="0.4064" k3="-0.3120"/>
+            <vignetting model="pa" focal="202" aperture="22" distance="1.6" k1="-0.1124" k2="0.0499" k3="0.0119"/>
+            <vignetting model="pa" focal="202" aperture="22" distance="81.91" k1="-0.1115" k2="0.0527" k3="0.0099"/>
+            <vignetting model="pa" focal="202" aperture="29" distance="1.6" k1="-0.1164" k2="0.0603" k3="0.0052"/>
+            <vignetting model="pa" focal="202" aperture="29" distance="81.91" k1="-0.1114" k2="0.0516" k3="0.0110"/>
+            <vignetting model="pa" focal="302" aperture="6.3" distance="1.6" k1="0.1016" k2="-0.9624" k3="0.5333"/>
+            <vignetting model="pa" focal="302" aperture="6.3" distance="81.91" k1="-0.4910" k2="-0.5126" k3="0.4763"/>
+            <vignetting model="pa" focal="302" aperture="9" distance="1.6" k1="-0.1485" k2="0.3171" k3="-0.2924"/>
+            <vignetting model="pa" focal="302" aperture="9" distance="81.91" k1="0.1783" k2="-0.9100" k3="0.4136"/>
+            <vignetting model="pa" focal="302" aperture="13" distance="1.6" k1="-0.0934" k2="0.0446" k3="0.0113"/>
+            <vignetting model="pa" focal="302" aperture="13" distance="81.91" k1="-0.1291" k2="0.3325" k3="-0.4118"/>
+            <vignetting model="pa" focal="302" aperture="18" distance="1.6" k1="-0.0954" k2="0.0499" k3="0.0074"/>
+            <vignetting model="pa" focal="302" aperture="18" distance="81.91" k1="-0.1502" k2="0.2800" k3="-0.2058"/>
+            <vignetting model="pa" focal="302" aperture="25" distance="1.6" k1="-0.0939" k2="0.0456" k3="0.0108"/>
+            <vignetting model="pa" focal="302" aperture="25" distance="81.91" k1="-0.0896" k2="0.0420" k3="0.0134"/>
+            <vignetting model="pa" focal="302" aperture="29" distance="1.6" k1="-0.0966" k2="0.0509" k3="0.0077"/>
+            <vignetting model="pa" focal="302" aperture="29" distance="81.91" k1="-0.0888" k2="0.0387" k3="0.0161"/>
+            <vignetting model="pa" focal="400" aperture="6.3" distance="1.6" k1="-0.0411" k2="-0.7695" k3="0.5147"/>
+            <vignetting model="pa" focal="400" aperture="6.3" distance="81.91" k1="-1.1032" k2="0.9441" k3="-0.3832"/>
+            <vignetting model="pa" focal="400" aperture="9" distance="1.6" k1="-0.1261" k2="0.2107" k3="-0.1597"/>
+            <vignetting model="pa" focal="400" aperture="9" distance="81.91" k1="0.1313" k2="-1.0189" k3="0.5973"/>
+            <vignetting model="pa" focal="400" aperture="13" distance="1.6" k1="-0.0991" k2="0.0664" k3="-0.0013"/>
+            <vignetting model="pa" focal="400" aperture="13" distance="81.91" k1="-0.0865" k2="0.1690" k3="-0.2476"/>
+            <vignetting model="pa" focal="400" aperture="18" distance="1.6" k1="-0.1050" k2="0.0772" k3="-0.0079"/>
+            <vignetting model="pa" focal="400" aperture="18" distance="81.91" k1="-0.0970" k2="0.0929" k3="-0.0346"/>
+            <vignetting model="pa" focal="400" aperture="25" distance="1.6" k1="-0.1097" k2="0.0847" k3="-0.0113"/>
+            <vignetting model="pa" focal="400" aperture="25" distance="81.91" k1="-0.0865" k2="0.0494" k3="0.0067"/>
+            <vignetting model="pa" focal="400" aperture="29" distance="1.6" k1="-0.1121" k2="0.0882" k3="-0.0127"/>
+            <vignetting model="pa" focal="400" aperture="29" distance="81.91" k1="-0.0870" k2="0.0492" k3="0.0074"/>
+
         </calibration>
     </lens>
     


### PR DESCRIPTION
This PR adds TCA & Vignetting for the existing Sigma 100-400 OS HSM Contemporary Lens

Taken with a Canon 6D. Vignetting test photos will be uploaded an linked a few minutes after I post this PR. Edit: https://github.com/lensfun/lensfun/issues/2773