### PR TITLE
Add distortion for Tamron 85mm f/1.8 VC

### DIFF
--- a/data/db/slr-tamron.xml
+++ b/data/db/slr-tamron.xml
@@ -2271,6 +2271,7 @@
         <cropfactor>1.005</cropfactor>
         <calibration>
             <!-- Taken with Canon 6D -->
+            <distortion model="ptlens" focal="85" a="-0.00186" b="0.00578" c="-0.00428"/>
             <tca model="poly3" focal="85" vr="1.00006" vb="1.00003"/>
             <vignetting model="pa" focal="85" aperture="1.8" distance="0.74" k1="-1.1846" k2="0.7583" k3="-0.2251"/>
             <vignetting model="pa" focal="85" aperture="1.8" distance="56.34" k1="-1.4786" k2="1.4753" k3="-0.6493"/>


### PR DESCRIPTION
This adds distortion to the Tamron 85mm definition that was recently added in #2771. The upload #2773 has checkable CR2 raws.
