### PR TITLE
Add Sony E-mount FE 50 f/1.4 GM

### DIFF
--- a/data/db/mil-sony.xml
+++ b/data/db/mil-sony.xml
@@ -2977,6 +2977,18 @@
 
     <lens>
         <maker>Sony</maker>
+        <model>FE 50mm f/1.4 GM</model>
+        <mount>Sony E</mount>
+        <cropfactor>1.0</cropfactor>
+        <calibration>
+            <!-- Taken with ILCE-7RM5, coeffients fitted from exif data by lf_fitexif_se -->
+            <distortion model="ptlens" focal="50" a="0.0214722" b="-0.0529950" c="0.0396203" />
+            <tca model="poly3" focal="50" vr="1.0001816" cr="-0.0003122" br="0.0001813" vb="1.0000015" cb="0.0003122" bb="-0.0001813" />
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Sony</maker>
         <model>FE 28-60mm f/4-5.6</model>
         <mount>Sony E</mount>
         <cropfactor>1.0</cropfactor>


### PR DESCRIPTION
Since I haven't owned a Sony camera, what I have is a Nikon Z8, a Sony FE50 f/1.4GM and a Megadap ETZ21 Pro.

I have to find the calibration data from someone else. Luckily, I found some test photo (took by A7R5) from dpreview.com which suitable for generate calibration data. [The photos can be found here](https://www.dpreview.com/samples/8378842578/sony-50mm-f1-4-gm-sample-gallery)

I used three photos with lf-fitexif to generate these correction data.

```
distortion/DSC01420.ARW
tca/DSC01489.ARW
vignetting/DSC01363.ARW
```