### PR TITLE
Add full-frame vignetting information for Canon RF 24mm f/1.8

### DIFF
--- a/data/db/mil-canon.xml
+++ b/data/db/mil-canon.xml
@@ -1837,9 +1837,20 @@
         <mount>Canon RF</mount>
         <cropfactor>1.0</cropfactor>
         <calibration>
-	     <!-- Taken with Canon EOS R6 -->
+	        <!-- Taken with Canon EOS R6 -->
             <distortion model="ptlens" focal="24" a="0.0157929" b="-0.071535" c="0.0199203"/>
             <tca model="poly3" focal="24" vr="1.0001912" vb="1.0000314"/>
+		    <!-- Taken with Canon EOS R6 Mark II -->
+            <vignetting model="pa" focal="24" aperture="1.8" distance="10" k1="-2.2478" k2="2.5079" k3="-1.1669"/>
+            <vignetting model="pa" focal="24" aperture="1.8" distance="1000" k1="-2.2478" k2="2.5079" k3="-1.1669"/>
+            <vignetting model="pa" focal="24" aperture="2" distance="10" k1="-1.8825" k2="1.6159" k3="-0.6226"/>
+            <vignetting model="pa" focal="24" aperture="2" distance="1000" k1="-1.8825" k2="1.6159" k3="-0.6226"/>
+            <vignetting model="pa" focal="24" aperture="2.8" distance="10" k1="-0.7101" k2="-0.0838" k3="0.0042"/>
+            <vignetting model="pa" focal="24" aperture="2.8" distance="1000" k1="-0.7101" k2="-0.0838" k3="0.0042"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="10" k1="-1.0544" k2="1.1437" k3="-0.7782"/>
+            <vignetting model="pa" focal="24" aperture="4" distance="1000" k1="-1.0544" k2="1.1437" k3="-0.7782"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="10" k1="-0.9071" k2="0.7539" k3="-0.4285"/>
+            <vignetting model="pa" focal="24" aperture="5.6" distance="1000" k1="-0.9071" k2="0.7539" k3="-0.4285"/>
         </calibration>
     </lens>
 


### PR DESCRIPTION
Contains vignetting data measured at f/1.8, f/2, f/2.8, f/4, and f/5.6 with a Canon EOS R6 Mark II, reusing the distortion data already provided.