### PR TITLE
Added an alias for newer revision of Minolta AF 50mm f1.4

### DIFF
--- a/data/db/slr-konica-minolta.xml
+++ b/data/db/slr-konica-minolta.xml
@@ -494,6 +494,7 @@
     <lens>
         <maker>Minolta</maker>
         <model>Minolta AF 50mm f/1.4</model>
+        <model>Minolta AF 50mm F1.4 [New]</model>
         <mount>Minolta AF</mount>
         <cropfactor>1</cropfactor>
         <calibration>

--- a/data/db/slr-konica-minolta.xml
+++ b/data/db/slr-konica-minolta.xml
@@ -494,6 +494,18 @@
     <lens>
         <maker>Minolta</maker>
         <model>Minolta AF 50mm f/1.4</model>
+        <mount>Minolta AF</mount>
+        <cropfactor>1</cropfactor>
+        <calibration>
+            <!-- Taken with Sony Alpha DSLR-A850 -->
+            <distortion model="poly3" focal="50" k1="-0.0044"/>
+            <tca model="poly3" focal="50" br="-0.0000693" vr="1.0002434" bb="0.0000918" vb="0.9996770"/>
+        </calibration>
+    </lens>
+
+    <lens>
+        <maker>Minolta</maker>
+	<!-- Same lens as above - some units report different model -->
         <model>Minolta AF 50mm F1.4 [New]</model>
         <mount>Minolta AF</mount>
         <cropfactor>1</cropfactor>


### PR DESCRIPTION
Hey,

I've got a revision of this lens which registers as "Minolta AF 50mm F1.4 [New]" in EXIF data - this simply adds an alias since it should be optically identical to the original.

Sample photo attached.
[DSC05631.zip](https://github.com/user-attachments/files/30857210/DSC05631.zip)

