### PR TITLE
Add vignetting profile for TTArtisan 40mm F2 Z

### DIFF
--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -2799,16 +2799,16 @@
         <calibration>
             <!-- Taken with Nikon Z5 -->
             <distortion model="ptlens" focal="40" a="0.00777613" b="-0.0172556" c="0.0143621"/>
-            <vignetting model="pa" focal="40.0" aperture="2.0" distance="10" k1="-2.3886628" k2="2.2177320" k3="-0.7846816" />
-            <vignetting model="pa" focal="40.0" aperture="2.0" distance="1000" k1="-2.3886628" k2="2.2177320" k3="-0.7846816" />
-            <vignetting model="pa" focal="40.0" aperture="2.8" distance="10" k1="-0.9313442" k2="-0.8695419" k3="0.8999519" />
-            <vignetting model="pa" focal="40.0" aperture="2.8" distance="1000" k1="-0.9313442" k2="-0.8695419" k3="0.8999519" />
-            <vignetting model="pa" focal="40.0" aperture="4.0" distance="10" k1="-0.4961205" k2="-1.1110817" k3="0.7256115" />
-            <vignetting model="pa" focal="40.0" aperture="4.0" distance="1000" k1="-0.4961205" k2="-1.1110817" k3="0.7256115" />
-            <vignetting model="pa" focal="40.0" aperture="5.6" distance="10" k1="-0.6596079" k2="-0.3352420" k3="0.1007541" />
-            <vignetting model="pa" focal="40.0" aperture="5.6" distance="1000" k1="-0.6596079" k2="-0.3352420" k3="0.1007541" />
-            <vignetting model="pa" focal="40.0" aperture="16.0" distance="10" k1="-1.0463351" k2="1.0964724" k3="-0.9180824" />
-            <vignetting model="pa" focal="40.0" aperture="16.0" distance="1000" k1="-1.0463351" k2="1.0964724" k3="-0.9180824" />
+            <vignetting model="pa" focal="40.0" aperture="2.0" distance="10" k1="-1.5061840" k2="1.0333813" k3="-0.3803857" />
+            <vignetting model="pa" focal="40.0" aperture="2.0" distance="1000" k1="-1.5061840" k2="1.0333813" k3="-0.3803857" />
+            <vignetting model="pa" focal="40.0" aperture="2.8" distance="10" k1="-0.5151243" k2="-0.6530992" k3="0.4336096" />
+            <vignetting model="pa" focal="40.0" aperture="2.8" distance="1000" k1="-0.5151243" k2="-0.6530992" k3="0.4336096" />
+            <vignetting model="pa" focal="40.0" aperture="4.0" distance="10" k1="-0.5884751" k2="0.1114576" k3="-0.1576988" />
+            <vignetting model="pa" focal="40.0" aperture="4.0" distance="1000" k1="-0.5884751" k2="0.1114576" k3="-0.1576988" />
+            <vignetting model="pa" focal="40.0" aperture="5.6" distance="10" k1="-0.7169158" k2="0.4763204" k3="-0.3457353" />
+            <vignetting model="pa" focal="40.0" aperture="5.6" distance="1000" k1="-0.7169158" k2="0.4763204" k3="-0.3457353" />
+            <vignetting model="pa" focal="40.0" aperture="16.0" distance="10" k1="-0.5765391" k2="-0.0595856" k3="0.1372440" />
+            <vignetting model="pa" focal="40.0" aperture="16.0" distance="1000" k1="-0.5765391" k2="-0.0595856" k3="0.1372440" />
         </calibration>
     </lens>
 

--- a/data/db/misc.xml
+++ b/data/db/misc.xml
@@ -2799,6 +2799,16 @@
         <calibration>
             <!-- Taken with Nikon Z5 -->
             <distortion model="ptlens" focal="40" a="0.00777613" b="-0.0172556" c="0.0143621"/>
+            <vignetting model="pa" focal="40.0" aperture="2.0" distance="10" k1="-2.3886628" k2="2.2177320" k3="-0.7846816" />
+            <vignetting model="pa" focal="40.0" aperture="2.0" distance="1000" k1="-2.3886628" k2="2.2177320" k3="-0.7846816" />
+            <vignetting model="pa" focal="40.0" aperture="2.8" distance="10" k1="-0.9313442" k2="-0.8695419" k3="0.8999519" />
+            <vignetting model="pa" focal="40.0" aperture="2.8" distance="1000" k1="-0.9313442" k2="-0.8695419" k3="0.8999519" />
+            <vignetting model="pa" focal="40.0" aperture="4.0" distance="10" k1="-0.4961205" k2="-1.1110817" k3="0.7256115" />
+            <vignetting model="pa" focal="40.0" aperture="4.0" distance="1000" k1="-0.4961205" k2="-1.1110817" k3="0.7256115" />
+            <vignetting model="pa" focal="40.0" aperture="5.6" distance="10" k1="-0.6596079" k2="-0.3352420" k3="0.1007541" />
+            <vignetting model="pa" focal="40.0" aperture="5.6" distance="1000" k1="-0.6596079" k2="-0.3352420" k3="0.1007541" />
+            <vignetting model="pa" focal="40.0" aperture="16.0" distance="10" k1="-1.0463351" k2="1.0964724" k3="-0.9180824" />
+            <vignetting model="pa" focal="40.0" aperture="16.0" distance="1000" k1="-1.0463351" k2="1.0964724" k3="-0.9180824" />
         </calibration>
     </lens>
 


### PR DESCRIPTION
This adds vignetting calibration data to the existing TTARTISAN 40mmF2.0Z entry in data/db/misc.xml, which previously only had distortion data.

**Equipment**

Camera: Nikon Z5 II (full-frame, crop 1.0)
Lens: TTArtisan 40mm F2 Z

**Method**

I followed the procedure described in [pixls.us - Create lens calibration data for Lensfun](https://pixls.us/articles/create-lens-calibration-data-for-lensfun/):

**Verification**

I tested the resulting profile in darktable's lens correction module against the photos taken with this lens and confirmed the vignetting is accurately compensated across the calibrated aperture range.